### PR TITLE
Added BoxEnterprise model

### DIFF
--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Auth\AuthRepository.cs" />
     <Compile Include="BoxClient.cs" />
     <Compile Include="Converter\BoxItemConverter.cs" />
+    <Compile Include="Models\BoxEnterprise.cs" />
     <Compile Include="Models\BoxFileVersion.cs" />
     <Compile Include="Wrappers\BoxError.cs" />
     <Compile Include="Wrappers\BoxMultiPartRequest.cs" />

--- a/Box.V2/Models/BoxEnterprise.cs
+++ b/Box.V2/Models/BoxEnterprise.cs
@@ -1,0 +1,19 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Box.V2.Models
+{
+    /// <summary>
+    /// Box mini representation of a enterprise
+    /// </summary>
+    class BoxEnterprise : BoxEntity
+    {
+        public const string FieldName = "name";
+
+        /// <summary>
+        /// The name of this enterprise
+        /// </summary>
+        [JsonProperty(PropertyName = FieldName)]
+        public string Name { get; private set; }
+    }
+}

--- a/Box.V2/Models/BoxUser.cs
+++ b/Box.V2/Models/BoxUser.cs
@@ -147,7 +147,7 @@ namespace Box.V2.Models
         /// Mini representation of this user’s enterprise, including the ID of its enterprise
         /// </summary>
         [JsonProperty(PropertyName = FieldEnterprise)]
-        public BoxEntity Enterprise { get; private set; }
+        public BoxEnterprise Enterprise { get; private set; }
 
     }
 }


### PR DESCRIPTION
Added a new model BoxEnterprise and updated BoxUser to reference the new model. The name property was missing from the Enterprise reference due to being of type BoxEntity.
