### PR TITLE
Allow for custom IAuthRepository implementations

### DIFF
--- a/Box.V2/BoxClient.cs
+++ b/Box.V2/BoxClient.cs
@@ -113,7 +113,19 @@ namespace Box.V2
         /// <summary>
         /// The Auth repository that holds the auth session
         /// </summary>
-        public AuthRepository Auth { get; set; }
+        private IAuthRepository _auth { get; set; }
+        public IAuthRepository Auth
+        {
+            get
+            {
+                return _auth;
+            }
+            set
+            {
+                _auth = value;
+                InitManagers();
+            }
+        }
 
         /// <summary>
         /// Allows resource managers to be registered and retrieved as plugins

--- a/Box.V2/Extensions/BoxResponseExtensions.cs
+++ b/Box.V2/Extensions/BoxResponseExtensions.cs
@@ -15,6 +15,19 @@ namespace Box.V2.Extensions
     /// </summary>
     public static class BoxResponseExtensions
     {
+	    /// <summary>
+        /// Parses the BoxResponse with the provided converter
+        /// </summary>
+        /// <typeparam name="T">The return type of the Box response</typeparam>
+        /// <param name="response">The response to parse</param>
+        /// <param name="converter">The converter to use for the conversion</param>
+        /// <returns></returns>
+        public static IBoxResponse<T> ApplyParseResults<T>(this IBoxResponse<T> response, IBoxConverter converter)
+            where T : class
+        {
+            return response.ParseResults(converter);
+        }
+	
         /// <summary>
         /// Parses the BoxResponse with the provided converter
         /// </summary>


### PR DESCRIPTION
Give developers the option to set there own implementation of IAuthRepository. This gives developers greater control of tokens so it doesn't take place behind the scenes. For example a developer may want to persist session properties to a database for later use. 
