### PR TITLE
Added asUser parameter to GetFolderItemsAsync

### DIFF
--- a/Box.V2/Config/Constants.cs
+++ b/Box.V2/Config/Constants.cs
@@ -100,6 +100,7 @@ namespace Box.V2.Config
 
             public const string UserAgent = "User-Agent";
             public const string AcceptEncoding = "Accept-Encoding";
+            public const string AsUser = "As-User";
 
             /*** Values ***/
             public const string RefreshToken = "refresh_token";

--- a/Box.V2/Managers/BoxFoldersManager.cs
+++ b/Box.V2/Managers/BoxFoldersManager.cs
@@ -101,6 +101,11 @@ namespace Box.V2.Managers
         /// <returns></returns>
         public async Task<BoxFolder> GetInformationAsync(string id, List<string> fields = null)
         {
+            return await GetInformationAsync(id, null, fields);
+        }
+
+        public async Task<BoxFolder> GetInformationAsync(string id, string asUser, List<string> fields = null)
+        {
             id.ThrowIfNullOrWhiteSpace("id");
 
             string accessToken = _auth.Session.AccessToken;
@@ -109,7 +114,7 @@ namespace Box.V2.Managers
                 .Param(ParamFields, fields);
 
 
-            IBoxResponse<BoxFolder> response = await ToResponseAsync<BoxFolder>(request).ConfigureAwait(false);
+            IBoxResponse<BoxFolder> response = await ToResponseAsync<BoxFolder>(request, asUser).ConfigureAwait(false);
 
             return response.ResponseObject;
         }

--- a/Box.V2/Managers/BoxFoldersManager.cs
+++ b/Box.V2/Managers/BoxFoldersManager.cs
@@ -44,6 +44,11 @@ namespace Box.V2.Managers
         /// <param name="offset"></param>
         public async Task<BoxCollection<BoxItem>> GetFolderItemsAsync(string id, int limit, int offset = 0, List<string> fields = null)
         {
+            return await GetFolderItemsAsync(id, null, limit, offset, fields);
+        }
+
+        public async Task<BoxCollection<BoxItem>> GetFolderItemsAsync(string id, string asUser, int limit, int offset = 0, List<string> fields = null)
+        {
             id.ThrowIfNullOrWhiteSpace("id");
 
             BoxRequest request = new BoxRequest(_config.FoldersEndpointUri, string.Format(Constants.ItemsPathString, id))
@@ -51,10 +56,11 @@ namespace Box.V2.Managers
                 .Param("offset", offset.ToString())
                 .Param(ParamFields, fields);
 
-            IBoxResponse<BoxCollection<BoxItem>> response = await ToResponseAsync<BoxCollection<BoxItem>>(request).ConfigureAwait(false);
+            IBoxResponse<BoxCollection<BoxItem>> response = await ToResponseAsync<BoxCollection<BoxItem>>(request, asUser).ConfigureAwait(false);
 
             return response.ResponseObject;
         }
+
 
         /// <summary>
         /// Used to create a new empty folder. The new folder will be created inside of the specified parent folder

--- a/Box.V2/Managers/BoxFoldersManager.cs
+++ b/Box.V2/Managers/BoxFoldersManager.cs
@@ -47,6 +47,15 @@ namespace Box.V2.Managers
             return await GetFolderItemsAsync(id, null, limit, offset, fields);
         }
 
+        /// <summary>
+        /// Retrieves the files and/or folders contained in the provided folder id as a given user.
+        /// </summary>
+        /// <param name="id"></param>
+        /// <param name="asUser"></param>
+        /// <param name="limit"></param>
+        /// <param name="offset"></param>
+        /// <param name="fields"></param>
+        /// <returns></returns>
         public async Task<BoxCollection<BoxItem>> GetFolderItemsAsync(string id, string asUser, int limit, int offset = 0, List<string> fields = null)
         {
             id.ThrowIfNullOrWhiteSpace("id");

--- a/Box.V2/Managers/BoxResourceManager.cs
+++ b/Box.V2/Managers/BoxResourceManager.cs
@@ -37,11 +37,15 @@ namespace Box.V2.Managers
             _auth = auth;
         }
 
-        protected IBoxRequest AddDefaultHeaders(IBoxRequest request)
+        protected IBoxRequest AddDefaultHeaders(IBoxRequest request, string asUser = null)
         {
             request
                 .Header(Constants.RequestParameters.UserAgent, _config.UserAgent)
                 .Header(Constants.RequestParameters.AcceptEncoding, _config.AcceptEncoding.ToString());
+
+            if (!string.IsNullOrEmpty(asUser))
+                request
+                    .Header(Constants.RequestParameters.AsUser, asUser);
 
             return request;
         }
@@ -49,7 +53,13 @@ namespace Box.V2.Managers
         protected async Task<IBoxResponse<T>> ToResponseAsync<T>(IBoxRequest request, bool queueRequest = false)
             where T : class
         {
-            AddDefaultHeaders(request);
+            return await ToResponseAsync<T>(request, null, queueRequest);
+        }
+
+        protected async Task<IBoxResponse<T>> ToResponseAsync<T>(IBoxRequest request, string asUser, bool queueRequest = false)
+            where T : class
+        {
+            AddDefaultHeaders(request, asUser);
             AddAuthorization(request);
             var response = await ExecuteRequest<T>(request, queueRequest).ConfigureAwait(false);
 


### PR DESCRIPTION
Needed to be able to traverse all folders for users in my organization.  I found that once I requested the root folder for a user I was able to traverse their folder structures without using the "As-User" header.  For that reason I limited my changes to GetFolderItemsAsync and some methods it calls.