### PR TITLE
Bubbled the exception details to client.(Issue #148)

### DIFF
--- a/Box.V2/Extensions/BoxResponseExtensions.cs
+++ b/Box.V2/Extensions/BoxResponseExtensions.cs
@@ -40,6 +40,11 @@ namespace Box.V2.Extensions
                         var err = new BoxError() { Code = response.StatusCode.ToString(), Description = "Forbidden", Message = errorMsg.ToString() };
                         throw new BoxException(err.Message, err);
                     }
+                    else if (!string.IsNullOrWhiteSpace(response.ContentString))
+                    {
+                        response.Error = converter.Parse<BoxError>(response.ContentString);
+                        throw new BoxException(response.ContentString, response.Error) {StatusCode = response.StatusCode};
+                    }
                     else
                     {
                         throw new BoxException("Forbidden");


### PR DESCRIPTION
This is to address the issue #148 - Insufficient Exception Information When Status Code 403 / Forbidden