### PR TITLE
fix so request is not retried for a 429 (rate limit) error on file up…

### DIFF
--- a/Box.V2/Exceptions/BoxException.cs
+++ b/Box.V2/Exceptions/BoxException.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Text;
 
 namespace Box.V2.Exceptions
@@ -47,6 +48,11 @@ namespace Box.V2.Exceptions
         /// Error parsed from the message returned by the API
         /// </summary>
         public BoxError Error { get; set; }
+
+        /// <summary>
+        /// Response headers returned by the API
+        /// </summary>
+        public HttpResponseHeaders ResponseHeaders { get; set; }
     }
 
 

--- a/Box.V2/Extensions/BoxResponseExtensions.cs
+++ b/Box.V2/Extensions/BoxResponseExtensions.cs
@@ -39,16 +39,16 @@ namespace Box.V2.Extensions
                     if (errorMsg != null)
                     {
                         var err = new BoxError() { Code = response.StatusCode.ToString(), Description = "Forbidden", Message = errorMsg.ToString() };
-                        throw new BoxException(err.Message, err);
+                        throw new BoxException(err.Message, err) { StatusCode = response.StatusCode, ResponseHeaders = response.Headers };
                     }
                     else if (!string.IsNullOrWhiteSpace(response.ContentString))
                     {
                         response.Error = converter.Parse<BoxError>(response.ContentString);
-                        throw new BoxException(response.ContentString, response.Error) {StatusCode = response.StatusCode};
+                        throw new BoxException(response.ContentString, response.Error) { StatusCode = response.StatusCode, ResponseHeaders = response.Headers };
                     }
                     else
                     {
-                        throw new BoxException("Forbidden");
+                        throw new BoxException("Forbidden") { StatusCode = response.StatusCode, ResponseHeaders = response.Headers };
                     }
                 default:
                     if (!string.IsNullOrWhiteSpace(response.ContentString))
@@ -61,11 +61,11 @@ namespace Box.V2.Extensions
                                     if (response is IBoxResponse<BoxPreflightCheck>)
                                     {
                                         BoxPreflightCheckConflictError<BoxFile> err = converter.Parse<BoxPreflightCheckConflictError<BoxFile>>(response.ContentString);
-                                        exToThrow = new BoxPreflightCheckConflictException<BoxFile>(response.ContentString, err);
+                                        exToThrow = new BoxPreflightCheckConflictException<BoxFile>(response.ContentString, err) { StatusCode = response.StatusCode, ResponseHeaders = response.Headers };
                                     } else
                                     {
                                         BoxConflictError<T> error = converter.Parse<BoxConflictError<T>>(response.ContentString);
-                                        exToThrow = new BoxConflictException<T>(response.ContentString, error);
+                                        exToThrow = new BoxConflictException<T>(response.ContentString, error) { StatusCode = response.StatusCode, ResponseHeaders = response.Headers };
                                     }
                                   
                                     break;
@@ -80,10 +80,10 @@ namespace Box.V2.Extensions
                         }
 
                         throw exToThrow == null ?
-                            new BoxException(response.ContentString, response.Error) { StatusCode = response.StatusCode } :
+                            new BoxException(response.ContentString, response.Error) { StatusCode = response.StatusCode, ResponseHeaders = response.Headers } :
                             exToThrow;
                     }
-                    throw new BoxException(response.ContentString) { StatusCode = response.StatusCode };
+                    throw new BoxException(response.ContentString) { StatusCode = response.StatusCode, ResponseHeaders = response.Headers };
             }
             return response;
         }


### PR DESCRIPTION
…loads (multipart request). The reason for this is that the stream has already been consumed by the time the error is received and there is not enough information about the stream to reset it.

Added a ResponseHeaders field to BoxException and set that value where appropriate (all response processing).