### PR TITLE
Allow creation of BoxJWTAuth objects without JWTPrivateKey and password

### DIFF
--- a/Box.V2.JWTAuth/BoxJWTAuth.cs
+++ b/Box.V2.JWTAuth/BoxJWTAuth.cs
@@ -48,6 +48,18 @@ namespace Box.V2.JWTAuth
         {
             this.boxConfig = boxConfig;
 
+            // the following allows creation of a BoxJWTAuth object without valid keys but with a valid JWT UserToken
+            // this allows code like this:
+
+            // var boxConfig = new BoxConfig("", "", "", "", "", "");
+            // var boxJwt = new BoxJWTAuth(boxConfig);
+            // const string userToken = "TOKEN_OBTAINED_BY_CALLING_FULL_BOXJWTAUTH";  // token valid for 1 hr.
+            // UserClient = boxJwt.UserClient(userToken, null);  // this user client can do normal file operations.
+
+            if (string.IsNullOrEmpty(boxConfig.JWTPrivateKey) || string.IsNullOrEmpty(boxConfig.JWTPrivateKeyPassword))
+	            return;
+
+
             var pwf = new PEMPasswordFinder(this.boxConfig.JWTPrivateKeyPassword);
             AsymmetricCipherKeyPair key;
             using (var reader = new StringReader(this.boxConfig.JWTPrivateKey))


### PR DESCRIPTION
Added a feature that allows using a userToken that was previously obtained by a call to the normal JWT Authentication mechanism. This allows a web-service to do the login with the full credentials - client programs can then call the web service to retrieve a token and then create a UserClient with only the userToken. That means the client has less sensitive data, and only gets access to a token that times out. Drawback is that the clients have to manage refreshing the access token.