### PR TITLE
Overwrite ToString() and updated Readme with 2nd example in section '…

### DIFF
--- a/Box.V2/Models/BoxItem.cs
+++ b/Box.V2/Models/BoxItem.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Text;
 
 namespace Box.V2.Models
 {
@@ -116,5 +117,23 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = FieldTags)]
         public string[] Tags { get; private set; }
+
+        public override string ToString()
+        {
+            StringBuilder pathBldr = new StringBuilder();
+            pathBldr.Append($"[{this.GetType()}] ");
+
+            if (this.PathCollection != null)
+            {
+                foreach (BoxFolder parentFolder in this.PathCollection.Entries)
+                {
+                    pathBldr.Append($"{parentFolder}/");
+                }
+            }
+
+            pathBldr.Append($"{this.Id}/{this.Name}");
+
+            return pathBldr.ToString();
+        }
     }
 }

--- a/Box.V2/Models/BoxUser.cs
+++ b/Box.V2/Models/BoxUser.cs
@@ -156,5 +156,10 @@ namespace Box.V2.Models
         [JsonProperty(PropertyName = FieldIsPlatformAccessOnly)]
         public bool? IsPlatformAccessOnly { get; private set; }
 
+
+        public override string ToString()
+        {
+            return $"[{this.GetType()}] {this.Id}/{ this.Name}";
+        }
     }
 }


### PR DESCRIPTION
I overwrote ToString() methods for BoxItem and BoxUser to be more meaningful during development.  I intended to have the full path of the BoxItem but the PathCollection property is always null for some reason.  I would really like to get that working eventually.  I also updated the help so show how to get all users and their respective folder.  Hope this helps.