### PR TITLE
added two test cases and minor change to the documentation for single…

### DIFF
--- a/Box.V2.Test.Integration/BoxCollaborationsManagerTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxCollaborationsManagerTestIntegration.cs
@@ -59,6 +59,49 @@ namespace Box.V2.Test.Integration
             Assert.IsTrue(success, "Collaboration deletion was unsucessful");
         }
 
+        // Test to add collaboration by Box User ID and Box Group ID. 
+        [TestMethod]
+        public async Task AddGroupCollaboration_File_Fields_ValidResponse()
+        {
+            const string fileId = "238288183114";
+            const string groupId = "176708848";
+            const string userId = "349294186";
+
+            // Add Group Collaboration
+            BoxCollaborationRequest addGroupRequest = new BoxCollaborationRequest()
+            {
+                Item = new BoxRequestEntity()
+                {
+                    Id = fileId,
+                    Type = BoxType.file
+                },
+                AccessibleBy = new BoxCollaborationUserRequest()
+                {
+                    Type = BoxType.group,
+                    Id = groupId
+                },
+                Role = "viewer"
+            };
+
+            //Add User Collaboration
+            BoxCollaborationRequest addUserRequest = new BoxCollaborationRequest()
+            {
+                Item = new BoxRequestEntity()
+                {
+                    Id = fileId,
+                    Type = BoxType.file
+                },
+                AccessibleBy = new BoxCollaborationUserRequest()
+                {
+                    Type = BoxType.user,
+                    Id = userId
+                },
+                Role = "editor"
+            };
+            var groupFileCollaboration = await _client.CollaborationsManager.AddCollaborationAsync(addGroupRequest, notify: false);
+            var userFileCollaboration = await _client.CollaborationsManager.AddCollaborationAsync(addUserRequest, notify: false);
+        }
+
         [TestMethod]
         public async Task CollaborationsOnFileWorkflow_LiveSession_ValidResponse()
         {

--- a/Box.V2/Managers/BoxCollaborationsManager.cs
+++ b/Box.V2/Managers/BoxCollaborationsManager.cs
@@ -19,7 +19,7 @@ namespace Box.V2.Managers
             : base(config, service, converter, auth, asUser, suppressNotifications) { }
 
         /// <summary>
-        /// Used to add a collaboration for a single user or a single group to a folder. 
+        /// Used to add a collaboration for a single user or a single group to a folder or file. 
         /// Either an email address, a user ID, or a group id can be used to create the collaboration. 
         /// If the collaboration is being created with a group, access to this endpoint is granted based on the group's invitability_level.
         /// </summary>

--- a/Box.V2/Models/Request/BoxCollaborationRequest.cs
+++ b/Box.V2/Models/Request/BoxCollaborationRequest.cs
@@ -9,7 +9,7 @@ namespace Box.V2.Models
     {
         /// <summary>
         /// The item to add the collaboration on
-        /// The ID and Type are required. The Type MUST also be folder
+        /// The ID and Type are required. The Type can be folder or file.
         /// </summary>
         [JsonProperty(PropertyName = "item")]
         public BoxRequestEntity Item { get; set; }


### PR DESCRIPTION
Hey Yang, very minor change to this in the documentation because we support files on top of folders now for file collaboration, let me know if this is necessary, thanks! 

I saw you had a test to add user collab on a single file by login so I added another one for adding single file collab with user ID and group ID. 

Thanks! 