### PR TITLE
Modified 'Status' property of the BoxRepresentationStatus class to overcome deserialization issue

### DIFF
--- a/Box.V2/Models/BoxRepresentationStatus.cs
+++ b/Box.V2/Models/BoxRepresentationStatus.cs
@@ -4,12 +4,12 @@ namespace Box.V2.Models
 {
     public class BoxRepresentationStatus
     {
-        public const string FieldStatus = "status";
+        public const string FieldState = "state";
 
         /// <summary>
         /// The status on generating the representation
         /// </summary>
-        [JsonProperty(PropertyName = FieldStatus)]
-        public string Status { get; private set; }
+        [JsonProperty(PropertyName = FieldState)]
+        public string State { get; private set; }
     }
 }


### PR DESCRIPTION
I was working with representations endpoint and found that the status of the representation is always null. I Inspected the endpoint with fiddler and realized that the response contains a property called 'state' where the BoxRepresentationStatus class has defined it as 'Status'. So i went ahead and renamed property name to 'State' and the Json property name to 'state' accordingly.