### PR TITLE
Help build tools find Box.V2.Core nuspec file

### DIFF
--- a/Box.V2.Core/Box.V2.Core.csproj
+++ b/Box.V2.Core/Box.V2.Core.csproj
@@ -13,6 +13,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <NuspecFile>Box.V2.Core.nuspec</NuspecFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
For some reason, the `dotnet` tool we use for release won't use the values in the nuspec file unless it's explicitly mentioned in the csproj file.  Adding this ensures that the package metadata for the Box.V2.Core project will be present in the nuget package.