### PR TITLE
Fix parsing for user tracking codes

### DIFF
--- a/Box.V2.Test/BoxUsersManagerTest.cs
+++ b/Box.V2.Test/BoxUsersManagerTest.cs
@@ -43,6 +43,48 @@ namespace Box.V2.Test
         }
 
         [TestMethod]
+        public async Task GetUserInformation_TrackingCodes()
+        {
+            /*** Arrange ***/
+            string responseString = @"{
+                ""type"": ""user"",
+                ""id"": ""12345"",
+                ""name"": ""Tracked User"",
+                ""tracking_codes"": [
+                    {
+                        ""type"": ""tracking_code"",
+                        ""name"": ""tc1"",
+                        ""value"": ""value1""
+                    },
+                    {
+                        ""type"": ""tracking_code"",
+                        ""name"": ""tc2"",
+                        ""value"": ""value2""
+                    }
+                ]
+            }";
+            Handler.Setup(h => h.ExecuteAsync<BoxUser>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxUser>>(new BoxResponse<BoxUser>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = responseString
+                }));
+
+            /*** Act ***/
+            string[] fields = { "name", "tracking_codes" };
+            BoxUser user = await _usersManager.GetCurrentUserInformationAsync(fields);
+
+            /*** Assert ***/
+            Assert.AreEqual("12345", user.Id);
+            Assert.AreEqual("Tracked User", user.Name);
+            Assert.AreEqual(2, user.TrackingCodes.Count);
+            Assert.AreEqual("tc1", user.TrackingCodes[0].Name);
+            Assert.AreEqual("value1", user.TrackingCodes[0].Value);
+            Assert.AreEqual("tc2", user.TrackingCodes[1].Name);
+            Assert.AreEqual("value2", user.TrackingCodes[1].Value);
+        }
+
+        [TestMethod]
         public async Task UpdateUser_ValidResponse_ValidUser()
         {
             /*** Arrange ***/

--- a/Box.V2.Test/BoxUsersManagerTest.cs
+++ b/Box.V2.Test/BoxUsersManagerTest.cs
@@ -210,7 +210,7 @@ namespace Box.V2.Test
             Assert.AreEqual(5368709120, result.SpaceAmount);
             Assert.AreEqual(0, result.SpaceUsed);
             Assert.AreEqual(1073741824, result.MaxUploadSize);
-            Assert.AreEqual(0, result.TrackingCodes.Length);
+            Assert.AreEqual(0, result.TrackingCodes.Count);
             Assert.AreEqual(false, result.CanSeeManagedUsers);
             Assert.AreEqual(false, result.IsSyncEnabled);
             Assert.AreEqual("active", result.Status);
@@ -274,7 +274,7 @@ namespace Box.V2.Test
             Assert.AreEqual(5368709120, result.SpaceAmount);
             Assert.AreEqual(0, result.SpaceUsed);
             Assert.AreEqual(2147483648, result.MaxUploadSize);
-            Assert.AreEqual(0, result.TrackingCodes.Length);
+            Assert.AreEqual(0, result.TrackingCodes.Count);
             Assert.AreEqual(true, result.CanSeeManagedUsers);
             Assert.AreEqual(true, result.IsSyncEnabled);
             Assert.AreEqual("active", result.Status);

--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -115,6 +115,7 @@
     <Compile Include="Models\BoxTaskAssignment.cs" />
     <Compile Include="Models\BoxTermsOfService.cs" />
     <Compile Include="Models\BoxTermsOfServiceUserStatuses.cs" />
+    <Compile Include="Models\BoxTrackingCode.cs" />
     <Compile Include="Models\BoxUserInvite.cs" />
     <Compile Include="Models\BoxWatermarkInfo.cs" />
     <Compile Include="Models\BoxWatermark.cs" />

--- a/Box.V2/Models/BoxTrackingCode.cs
+++ b/Box.V2/Models/BoxTrackingCode.cs
@@ -1,0 +1,33 @@
+﻿using Newtonsoft.Json;
+using System;
+
+namespace Box.V2.Models
+{
+    /// <summary>
+    /// Box representation of a tracking code
+    /// </summary>
+    public class BoxTrackingCode
+    {
+        public const string FieldType = "type";
+        public const string FieldName = "name";
+        public const string FieldValue = "value";
+
+        /// <summary>
+        /// The type of the tracking code, should be tracking_code
+        /// </summary>
+        [JsonProperty(PropertyName = FieldType)]
+        public string Type { get; private set; }
+
+        /// <summary>
+        /// The name of the tracking code
+        /// </summary>
+        [JsonProperty(PropertyName = FieldName)]
+        public string Name { get; private set; }
+
+        /// <summary>
+        /// The value of the tracking code
+        /// </summary>
+        [JsonProperty(PropertyName = FieldValue)]
+        public string Value { get; private set; }
+    }
+}

--- a/Box.V2/Models/BoxUser.cs
+++ b/Box.V2/Models/BoxUser.cs
@@ -1,5 +1,6 @@
 ﻿using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 
 namespace Box.V2.Models
 {
@@ -88,7 +89,7 @@ namespace Box.V2.Models
         /// An array of key/value pairs set by the user’s admin
         /// </summary>
         [JsonProperty(PropertyName = FieldTrackingCodes)]
-        public string[] TrackingCodes { get; private set; }
+        public IList<BoxTrackingCode> TrackingCodes { get; private set; }
 
         /// <summary>
         /// Whether this user can see other enterprise users in its contact list

--- a/Box.V2/Models/Request/BoxUserRequest.cs
+++ b/Box.V2/Models/Request/BoxUserRequest.cs
@@ -1,4 +1,5 @@
 ﻿using Newtonsoft.Json;
+using System.Collections.Generic;
 
 namespace Box.V2.Models
 {
@@ -71,7 +72,7 @@ namespace Box.V2.Models
         /// An array of key/value pairs set by the user’s admin
         /// </summary>
         [JsonProperty(PropertyName = "tracking_codes")]
-        public string[] TrackingCodes { get; set; }
+        public IList<BoxTrackingCode> TrackingCodes { get; set; }
 
         /// <summary>
         /// Whether this user can see other enterprise users in its contact list


### PR DESCRIPTION
Moving the original change by @allenmichael to a feature branch in the SDK proper so CI tests pass.  Fixes #424 
