### PR TITLE
Fix protocol not supported error in .NET Core on MacOS

### DIFF
--- a/Box.V2/Request/HttpRequestHandler.cs
+++ b/Box.V2/Request/HttpRequestHandler.cs
@@ -186,7 +186,7 @@ namespace Box.V2.Request
                 handler.AllowAutoRedirect = followRedirect;
                 // Ensure that clients use non-deprecated versions of TLS (i.e. TLSv1.1 or greater)
 #if NETSTANDARD1_6
-                handler.SslProtocols |= System.Security.Authentication.SslProtocols.Tls11 | System.Security.Authentication.SslProtocols.Tls12;
+                handler.SslProtocols |= System.Security.Authentication.SslProtocols.Tls12;
 #elif NET45
                 System.Net.ServicePointManager.SecurityProtocol |= System.Net.SecurityProtocolType.Tls11 | System.Net.SecurityProtocolType.Tls12;
 #else


### PR DESCRIPTION
Setting both `Tlsv11` and `Tlsv12` causes an error in .NET Core on MacOS — switching to just one or the other appears to resolve the issue.  Since TLSv1.2 is the preferred version, we will set that one to maximize security going forward.