### PR TITLE
Conditionally serialize unshared_at property

### DIFF
--- a/Box.V2.Test/BoxFilesManagerTest.cs
+++ b/Box.V2.Test/BoxFilesManagerTest.cs
@@ -1,4 +1,4 @@
-﻿using Box.V2.Managers;
+using Box.V2.Managers;
 using Box.V2.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
@@ -317,6 +317,76 @@ namespace Box.V2.Test
             Assert.AreEqual("sean@box.com", f.CreatedBy.Login);
             Assert.AreEqual("user", f.CreatedBy.Type);
             Assert.AreEqual("17738362", f.CreatedBy.Id);
+        }
+
+        [TestMethod]
+        [TestCategory("CI-UNIT-TEST")]
+        public async Task EditSharedLink_NullUnsharedAt_ValidResponse()
+        {
+            /*** Arrange ***/
+            string responseString = "{ \"type\": \"file\", \"id\": \"5000948880\", \"sequence_id\": \"3\", \"etag\": \"3\", \"sha1\": \"134b65991ed521fcfe4724b7d814ab8ded5185dc\", \"name\": \"tigers.jpeg\", \"description\": \"a picture of tigers\", \"size\": 629644, \"path_collection\": { \"total_count\": 2, \"entries\": [ { \"type\": \"folder\", \"id\": \"0\", \"sequence_id\": null, \"etag\": null, \"name\": \"All Files\" }, { \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\" } ] }, \"created_at\": \"2012-12-12T10:55:30-08:00\", \"modified_at\": \"2012-12-12T11:04:26-08:00\", \"created_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"modified_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"owned_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"shared_link\": { \"url\": \"https://www.box.com/s/rh935iit6ewrmw0unyul\", \"download_url\": \"https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg\", \"vanity_url\": null, \"is_password_enabled\": false, \"unshared_at\": null, \"download_count\": 0, \"preview_count\": 0, \"access\": \"open\", \"permissions\": { \"can_download\": true, \"can_preview\": true } }, \"parent\": { \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\" }, \"item_status\": \"active\" }";
+            IBoxRequest boxRequest = null;
+            Handler.Setup(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = responseString
+                }))
+                .Callback<IBoxRequest>(r => boxRequest = r);
+
+            BoxSharedLinkRequest sharedLink = new BoxSharedLinkRequest()
+            {
+                UnsharedAt = null
+            };
+
+            var fileRequest = new BoxFileRequest()
+            {
+                Id = "5000948880",
+                SharedLink = sharedLink
+            };
+
+            /*** Act ***/
+            BoxFile f = await _filesManager.UpdateInformationAsync(fileRequest);
+
+            /*** Assert ***/
+            Assert.AreEqual("{\"shared_link\":{\"access\":null,\"unshared_at\":null},\"id\":\"5000948880\"}", boxRequest.Payload);
+            Assert.AreEqual("5000948880", f.Id);
+            Assert.IsNull(f.SharedLink.UnsharedAt);
+        }
+
+        [TestMethod]
+        [TestCategory("CI-UNIT-TEST")]
+        public async Task EditSharedLink_UnsetUnsharedAt_ValidResponse()
+        {
+            /*** Arrange ***/
+            string responseString = "{ \"type\": \"file\", \"id\": \"5000948880\", \"sequence_id\": \"3\", \"etag\": \"3\", \"sha1\": \"134b65991ed521fcfe4724b7d814ab8ded5185dc\", \"name\": \"tigers.jpeg\", \"description\": \"a picture of tigers\", \"size\": 629644, \"path_collection\": { \"total_count\": 2, \"entries\": [ { \"type\": \"folder\", \"id\": \"0\", \"sequence_id\": null, \"etag\": null, \"name\": \"All Files\" }, { \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\" } ] }, \"created_at\": \"2012-12-12T10:55:30-08:00\", \"modified_at\": \"2012-12-12T11:04:26-08:00\", \"created_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"modified_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"owned_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"shared_link\": { \"url\": \"https://www.box.com/s/rh935iit6ewrmw0unyul\", \"download_url\": \"https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg\", \"vanity_url\": null, \"is_password_enabled\": false, \"unshared_at\": null, \"download_count\": 0, \"preview_count\": 0, \"access\": \"open\", \"permissions\": { \"can_download\": true, \"can_preview\": true } }, \"parent\": { \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\" }, \"item_status\": \"active\" }";
+            IBoxRequest boxRequest = null;
+            Handler.Setup(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = responseString
+                }))
+                .Callback<IBoxRequest>(r => boxRequest = r);
+
+            BoxSharedLinkRequest sharedLink = new BoxSharedLinkRequest()
+            {
+                Access = BoxSharedLinkAccessType.open
+            };
+
+            var fileRequest = new BoxFileRequest()
+            {
+                Id = "5000948880",
+                SharedLink = sharedLink
+            };
+
+            /*** Act ***/
+            BoxFile f = await _filesManager.UpdateInformationAsync(fileRequest);
+
+            /*** Assert ***/
+            Assert.AreEqual("{\"shared_link\":{\"access\":\"open\"},\"id\":\"5000948880\"}", boxRequest.Payload);
+            Assert.AreEqual("5000948880", f.Id);
+            Assert.IsNull(f.SharedLink.UnsharedAt);
         }
 
         [TestMethod]

--- a/Box.V2/Models/Request/BoxSharedLinkRequest.cs
+++ b/Box.V2/Models/Request/BoxSharedLinkRequest.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
 
@@ -16,11 +16,31 @@ namespace Box.V2.Models
         [JsonConverter(typeof(StringEnumConverter))]
         public BoxSharedLinkAccessType? Access { get; set; }
 
+        private bool IsUnsharedAtSet = false;
+        private DateTime? _unsharedAt;
+
         /// <summary>
         /// The day that this link should be disabled at. Timestamps are rounded off to the given day.
         /// </summary>
-        [JsonProperty(PropertyName = "unshared_at")]
-        public DateTime? UnsharedAt { get; set; }
+        [JsonProperty(PropertyName = "unshared_at", NullValueHandling = NullValueHandling.Include)]
+        public DateTime? UnsharedAt
+        {
+            get
+            {
+                return _unsharedAt;
+            }
+
+            set
+            {
+                _unsharedAt = value;
+                IsUnsharedAtSet = true;
+            }
+        }
+
+        public bool ShouldSerializeUnsharedAt()
+        {
+            return IsUnsharedAtSet;
+        }
 
         /// <summary>
         /// The set of permissions that apply to this link


### PR DESCRIPTION
Use conditional serialization to ensure that the shared link `unshared_at` property is correctly sent to the API:

- A `null` value should be sent to the API
- The `null` value should not be sent if the user did not actively set it

Fixes #512 