### PR TITLE
Override Id property in EventSource classes

### DIFF
--- a/Box.V2/Models/BoxGroupEventSource.cs
+++ b/Box.V2/Models/BoxGroupEventSource.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Box.V2.Models
 {
@@ -14,8 +14,11 @@ namespace Box.V2.Models
         /// The unique id of the group resource.
         /// </summary>
         [JsonProperty(PropertyName = FieldGroupId)]
-        public string Id { get; private set; }
+        public override string Id { get; protected set; }
 
+        /// <summary>
+        /// The type of the object.
+        /// </summary>
         public override string Type { get { return "group"; } protected set { return; } }
 
         /// <summary>

--- a/Box.V2/Models/BoxGroupFileCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxGroupFileCollaborationEventSource.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Box.V2.Models
 {
@@ -10,20 +10,38 @@ namespace Box.V2.Models
         public const string FieldGroupName = "group_name";
         public const string FieldParent = "parent";
 
+        /// <summary>
+        /// The unique ID of the file being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldFileId)]
-        public string Id { get; private set; }
+        public override string Id { get; protected set; }
 
+        /// <summary>
+        /// The type of the object.
+        /// </summary>
         public override string Type { get { return "file"; } protected set { return; } }
 
+        /// <summary>
+        /// The name of the file being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldFileName)]
         public string Name { get; private set; }
 
+        /// <summary>
+        /// The unique ID of the group collaborating on the file.
+        /// </summary>
         [JsonProperty(PropertyName = FieldGroupId)]
         public string GroupId { get; private set; }
 
+        /// <summary>
+        /// The name of the group collaborating on the file.
+        /// </summary>
         [JsonProperty(PropertyName = FieldGroupName)]
         public string GroupName { get; private set; }
 
+        /// <summary>
+        /// The parent folder of the file being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldParent)]
         public BoxFolder Parent { get; private set; }
     }

--- a/Box.V2/Models/BoxGroupFolderCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxGroupFolderCollaborationEventSource.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Box.V2.Models
 {
@@ -10,20 +10,38 @@ namespace Box.V2.Models
         public const string FieldGroupName = "group_name";
         public const string FieldParent = "parent";
 
+        /// <summary>
+        /// The unique ID of the folder being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldFolderId)]
-        public string Id { get; private set; }
+        public override string Id { get; protected set; }
 
+        /// <summary>
+        /// The type of the object.
+        /// </summary>
         public override string Type { get { return "folder"; } protected set { return; } }
 
+        /// <summary>
+        /// The name of the folder being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldFolderName)]
         public string Name { get; private set; }
 
+        /// <summary>
+        /// The unique ID of the group collaborating on the folder.
+        /// </summary>
         [JsonProperty(PropertyName = FieldGroupId)]
         public string GroupId { get; private set; }
 
+        /// <summary>
+        /// The name of the group collaborating on the folder.
+        /// </summary>
         [JsonProperty(PropertyName = FieldGroupName)]
         public string GroupName { get; private set; }
 
+        /// <summary>
+        /// The parent folder of the folder being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldParent)]
         public BoxFolder Parent { get; private set; }
     }

--- a/Box.V2/Models/BoxUserFileCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxUserFileCollaborationEventSource.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Box.V2.Models
 {
@@ -10,20 +10,38 @@ namespace Box.V2.Models
         public const string FieldUserName = "user_name";
         public const string FieldParent = "parent";
 
+        /// <summary>
+        /// The unique ID of the file being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldFileId)]
-        public string Id { get; private set; }
+        public override string Id { get; protected set; }
 
+        /// <summary>
+        /// The type of the object.
+        /// </summary>
         public override string Type { get { return "file"; } protected set { return; } }
 
+        /// <summary>
+        /// The name of the file being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldFileName)]
         public string Name { get; private set; }
 
+        /// <summary>
+        /// The unique ID of the user collaborating on the file.
+        /// </summary>
         [JsonProperty(PropertyName = FieldUserId)]
         public string UserId { get; private set; }
 
+        /// <summary>
+        /// The name of the user collaborating on the file.
+        /// </summary>
         [JsonProperty(PropertyName = FieldUserName)]
         public string UserName { get; private set; }
 
+        /// <summary>
+        /// The parent folder of the file being collaborated on.
+        /// </summary>
         [JsonProperty(PropertyName = FieldParent)]
         public BoxFolder Parent { get; private set; }
     }

--- a/Box.V2/Models/BoxUserFolderCollaborationEventSource.cs
+++ b/Box.V2/Models/BoxUserFolderCollaborationEventSource.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 
 namespace Box.V2.Models
 {
@@ -14,33 +14,36 @@ namespace Box.V2.Models
         public const string FieldParent = "parent";
 
         /// <summary>
-        /// The Id of the folder.
+        /// The unique ID of the folder being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldFolderId)]
         public override string Id { get; protected set; }
 
+        /// <summary>
+        /// The type of the object.
+        /// </summary>
         public override string Type { get { return "folder"; } protected set { return; }}
 
         /// <summary>
-        /// The name of the folder.
+        /// The name of the folder  being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldFolderName)]
         public string Name { get; private set; }
 
         /// <summary>
-        /// The Id of the user.
+        /// The Id of the user collaborating on the folder.
         /// </summary>
         [JsonProperty(PropertyName = FieldUserId)]
         public string UserId { get; private set; }
 
         /// <summary>
-        /// The name of the folder.
+        /// The name of the user collaborating on the folder.
         /// </summary>
         [JsonProperty(PropertyName = FieldUserName)]
         public string UserName { get; private set; }
 
         /// <summary>
-        /// The parent folder.
+        /// The parent folder of the folder being collaborated on.
         /// </summary>
         [JsonProperty(PropertyName = FieldParent)]
         public BoxFolder Parent { get; private set; }


### PR DESCRIPTION
Many of the EventSource classes defined an `Id` property which shadows the base `BoxEntity` property of the same name.  Without marking the subclass property as `override`, the data exposed would vary depending on how the object was cast.  Marking the property as `override` should ensure that the correct data is always exposed.

Fixes #535 