### PR TITLE
Fix deserialization of translated task assignment status

### DIFF
--- a/Box.V2.Test/BoxTasksManagerTest.cs
+++ b/Box.V2.Test/BoxTasksManagerTest.cs
@@ -295,7 +295,7 @@ namespace Box.V2.Test
             /*** Assert ***/
 
             Assert.AreEqual("incomplete", result.Status);
-            Assert.AreEqual("未完了", result.StatusTranslated);
+            Assert.AreEqual("未完了", result.LocalizedStatus);
             Assert.AreEqual(ResolutionStateType.incomplete, result.ResolutionState);
         }
 

--- a/Box.V2/Models/BoxTaskAssignment.cs
+++ b/Box.V2/Models/BoxTaskAssignment.cs
@@ -58,7 +58,7 @@ namespace Box.V2.Models
         /// <summary>
         /// Gets the state of the resolution.
         /// </summary>
-        [Obsolete("This field is deprecated, and may not work consistently.  Use Status or StatusTranslated instead.")]
+        [Obsolete("This field is deprecated, and may not work consistently.  Use Status or LocalizedStatus instead.")]
         public ResolutionStateType? ResolutionState {
             get
             {
@@ -73,10 +73,10 @@ namespace Box.V2.Models
         public string Status { get; private set; }
 
         /// <summary>
-        /// Gets the translated/human-readable resolution status of the task assignment.
+        /// Gets the localized/human-readable resolution status of the task assignment.
         /// </summary>
         [JsonProperty(PropertyName = FieldResolutionState)]
-        public string StatusTranslated { get; private set; }
+        public string LocalizedStatus { get; private set; }
 
         /// <summary>
         ///Gets user assigned by.

--- a/Box.V2/Models/BoxTaskAssignment.cs
+++ b/Box.V2/Models/BoxTaskAssignment.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using System;
 
@@ -16,6 +16,7 @@ namespace Box.V2.Models
         public const string FieldAssignedAt = "assigned_at";
         public const string FieldRemindedAt = "reminded_at";
         public const string FieldResolutionState = "resolution_state";
+        public const string FieldStatus = "status";
         public const string FieldAssignedBy = "assigned_by";
 
         /// <summary>
@@ -57,9 +58,25 @@ namespace Box.V2.Models
         /// <summary>
         /// Gets the state of the resolution.
         /// </summary>
+        [Obsolete("This field is deprecated, and may not work consistently.  Use Status or StatusTranslated instead.")]
+        public ResolutionStateType? ResolutionState {
+            get
+            {
+                return (ResolutionStateType) System.Enum.Parse(typeof(ResolutionStateType), Status, ignoreCase: true);
+            }
+        }
+
+        /// <summary>
+        /// Gets the resolution status of the task assignment.
+        /// </summary>
+        [JsonProperty(PropertyName = FieldStatus)]
+        public string Status { get; private set; }
+
+        /// <summary>
+        /// Gets the translated/human-readable resolution status of the task assignment.
+        /// </summary>
         [JsonProperty(PropertyName = FieldResolutionState)]
-        [JsonConverter(typeof(StringEnumConverter))]
-        public ResolutionStateType? ResolutionState { get; private set; }
+        public string StatusTranslated { get; private set; }
 
         /// <summary>
         ///Gets user assigned by.


### PR DESCRIPTION
The `resolution_state` field of a task assignment can inadvertently contain localized text, which breaks the automatic deserialization into an enum and will throw as soon as the object is created.  The current enum solution seems too brittle, so it has been deprecated in favor of two new `string` properties: `.StatusTranslated` for the localized text and `.Status` for the new `status` field that will only contain the enum string values.  The deprecated `.ResolutionState` property has been re-implemented to convert to enum from the `status` field, which should prevent it from throwing on instantiation while maintaining backward compatibility.

Fixes #529 