### PR TITLE
Tag code samples for usage in developer docs

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -36,6 +36,7 @@ token from your application's
 
 The following example creates an API client with a developer token:
 
+<!-- sample get_authorize -->
 ```c#
 var config = new BoxConfig("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET", new Uri("http://localhost"));
 var session = new OAuthSession("YOUR_DEVELOPER_TOKEN", "N/A", 3600, "bearer");

--- a/docs/collaboration-whitelist.md
+++ b/docs/collaboration-whitelist.md
@@ -28,6 +28,7 @@ You can whitelist a certain domain to allow collaboration with that domain for y
 enterprise by calling
 `CollaborationWhitelistManager.AddCollaborationWhitelistEntryAsync(string domainToWhitelist, string directionForWhitelist)`.
 
+<!-- sample post_collaboration_whitelist_entries -->
 ```c#
 BoxCollaborationWhitelistEntry entry = await client.CollaborationWhitelistManager.AddCollaborationWhitelistEntryAsync(
     "example.com",
@@ -42,6 +43,7 @@ Information about a specific collaboration whitelist record, which shows
 the domain that is whitelisted, can be retrieved by calling
 `CollaborationWhitelistManager.GetCollaborationWhitelistEntryAsync(string id, IEnumerable<string> fields = null)`.
 
+<!-- sample get_collaboration_whitelist_entries_id -->
 ```c#
 string entryID = "11111";
 BoxCollaborationWhitelistEntry entry = await client.CollaborationWhitelistManager.GetCollaborationWhitelistEntryAsync(
@@ -55,6 +57,7 @@ Get Whitelisted Domains for an Enterprise
 You can retrieve the collection of whitelisted domains for an enterprise by calling
 `CollaborationWhitelistManager.GetAllCollaborationWhitelistEntriesAsync(int limit= 100, string nextMarker = null, bool autoPaginate = false)`.
 
+<!-- sample get_collaboration_whitelist_entries -->
 ```c#
 BoxCollectionMarkerBased<BoxCollaborationWhitelistEntry> whitelistedDomains = await client.CollaborationWhitelistManager
     .GetAllCollaborationWhitelistEntriesAsync();
@@ -70,6 +73,7 @@ Remove a Domain from Collaboration Whitelist
 You can remove a domain from the collaboration whitelist by calling
 `CollaborationWhitelistManager.DeleteCollaborationWhitelistEntryAsync(string id)`.
 
+<!-- sample delete_collaboration_whitelist_entries_id -->
 ```c#
 string entryID = "11111";
 await client.CollaborationWhitelistManager.DeleteCollaborationWhitelistEntryAsync(entryID);
@@ -82,6 +86,7 @@ You can make a specific user exempt from the collaboration whitelist, which
 allows them to collaborate with users from any domain, by calling
 `CollaborationWhitelistManager.AddCollaborationWhitelistExemptUserAsync(string userId)`.
 
+<!-- sample post_collaboration_whitelist_exempt_targets -->
 ```c#
 string userId = "22222";
 BoxCollaborationWhitelistTargetEntry exemptUser = await client.CollaborationWhitelistManager
@@ -94,6 +99,7 @@ Get an Exempt User's Information
 To retrieve information about a specific user exemption record, you can use
 `CollaborationWhitelistManager.GetCollaborationWhitelistExemptUserAsync(string id, IEnumerable<string> fields = null)`.
 
+<!-- sample get_collaboration_whitelist_exempt_targets_id -->
 ```c#
 string exemptionID = "33333";
 BoxCollaborationWhitelistTargetEntry exemptUser = await client.CollaborationWhitelistManager
@@ -107,6 +113,7 @@ To retrieve a collection of users who are exempt from the collaboration whitelis
 for an enterprise, call
 `CollaborationWhitelistManager.GetAllCollaborationWhitelistExemptUsersAsync(int limit = 100, string nextMarker = null, bool autoPaginate = false)`.
 
+<!-- sample get_collaboration_whitelist_exempt_targets -->
 ```c#
 BoxCollectionMarkerBased<BoxCollaborationWhitelistTargetEntry> = await client.CollaborationWhitelistManager
     .GetAllCollaborationWhitelistExemptUsersAsync();
@@ -122,6 +129,7 @@ To remove a user exemption from collaboration whitelist and make that user
 subject to whitelist restrictions again, you can call
 `CollaborationWhitelistManager.DeleteCollaborationWhitelistExemptUserAsync(string id)`.
 
+<!-- sample delete_ollaboration_whitelist_exempt_targets_id -->
 ```c#
 string exemptionId = "55555";
 await client.CollaborationWhitelistManager.DeleteCollaborationWhitelistExemptUserAsync(exemptionId);

--- a/docs/collaborations.md
+++ b/docs/collaborations.md
@@ -26,6 +26,7 @@ A collaboration can be added for an existing user by calling
 The `Role` field of the `collaborationRequest` parameter determines what permissions the collaborator will have on the
 folder or file. 
 
+<!-- sample post_collaborations -->
 ```c#
 // collaborate folder 11111 with user 22222
 BoxCollaborationRequest requestParams = new BoxCollaborationRequest()
@@ -54,6 +55,7 @@ A collaboration can be edited by calling
 `CollaborationsManager.EditCollaborationAsync(BoxCollaborationRequest collaborationRequest, IEnumerable<string> fields = null)`
 with the fields to be updated.  For example, to change the role of a collaboration:
 
+<!-- sample put_collaborations_id -->
 ```c#
 BoxCollaborationRequest requestParams = new BoxCollaborationRequest()
 {
@@ -69,6 +71,7 @@ Remove a Collaboration
 A collaboration can be removed by calling `CollaborationsManager.RemoveCollaborationAsync(string id)`.
 This will generally remove the user or group's access to the collaborated item.
 
+<!-- sample delete_collaborations_id -->
 ```c#
 await client.CollaborationsManager.RemoveCollaborationAsync(id: "12345");
 ```
@@ -80,6 +83,7 @@ To get information about a specific collaboration record, call
 `CollaborationsManager.GetCollaborationAsync(string id, IEnumerable<string> fields = null)` with the
 ID of the collaboration.
 
+<!-- get delete_collaborations_id -->
 ```c#
 BoxCollaboration collab = await client.CollaborationsManager.GetCollaborationAsync(id: "22222");
 ```
@@ -90,6 +94,7 @@ Get the Collaborations on a Folder
 You can get all of the collaborations on a folder by calling
 `FoldersManager.GetCollaborationsAsync(string id, IEnumerable<string> fields = null)` with the ID of the folder.
 
+<!-- sample delete_collaborations_id -->
 ```c#
 string folderId = "11111";
 BoxCollection<BoxCollaboration> collaborations = await client.FoldersManager
@@ -115,6 +120,7 @@ Get Pending Collaborations
 A collection of all the user's pending collaborations can be retrieved with
 `CollaborationsManager.GetPendingCollaborationAsync(IEnumerable<string> fields = null)`.
 
+<!-- sample get_collaborations -->
 ```c#
 BoxCollection<BoxCollaboration> pendingCollabs = await CollaborationsManager
     .GetPendingCollaborationAsync();

--- a/docs/collaborations.md
+++ b/docs/collaborations.md
@@ -83,7 +83,7 @@ To get information about a specific collaboration record, call
 `CollaborationsManager.GetCollaborationAsync(string id, IEnumerable<string> fields = null)` with the
 ID of the collaboration.
 
-<!-- get delete_collaborations_id -->
+<!-- sample get_collaborations_id -->
 ```c#
 BoxCollaboration collab = await client.CollaborationsManager.GetCollaborationAsync(id: "22222");
 ```
@@ -94,7 +94,7 @@ Get the Collaborations on a Folder
 You can get all of the collaborations on a folder by calling
 `FoldersManager.GetCollaborationsAsync(string id, IEnumerable<string> fields = null)` with the ID of the folder.
 
-<!-- sample delete_collaborations_id -->
+<!-- sample get_folders_id_collaborations -->
 ```c#
 string folderId = "11111";
 BoxCollection<BoxCollaboration> collaborations = await client.FoldersManager

--- a/docs/collections.md
+++ b/docs/collections.md
@@ -20,6 +20,7 @@ Get a User's Collections
 Get a list of all collections the user has defined by calling `CollectionsManager.GetCollectionsAsync()`.
 A user always has a default collection called "Favorites" which they can add items to.
 
+<!-- sample get_collections -->
 ```c#
 BoxCollection<BoxCollectionItem> collections = await client.CollectionsManager.GetCollectionsAsync();
 ```
@@ -30,6 +31,7 @@ Get the Items in a Collection
 Get a list of the items in a collection by passing the ID of the collection to
 `CollectionsManager.GetCollectionItemsAsync(string collectionId, int limit = 100, int offset = 0, IEnumerable<string> fields = null, bool autoPaginate = false)`.
 
+<!-- sample get_collections_id_items -->
 ```c#
 BoxCollection<BoxItem> items = await client.CollectionsManager.GetCollectionItemsAsync(id: "11111");
 ```

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -35,7 +35,7 @@ You can get all of the comments on a file by calling
 `FilesManager.GetCommentsAsync(string id, IEnumerable<string> fields = null)`
 with the ID of the file.
 
-<!-- sample get_comments_id -->
+<!-- sample get_comments -->
 ```c#
 string fileId = "11111";
 BoxCollection<BoxComment> comments = await client.FilesManager.GetCommentsAsync(fileId);

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -23,6 +23,7 @@ To get information about a specific comment, call
 `CommentsManager.GetInformationAsync(string id, IEnumerable<string> fields = null)`
 with the ID of the comment.
 
+<!-- sample get_comments_id -->
 ```c#
 BoxComment comment = await client.CommentsManager.GetInformationAsync(id: "11111");
 ```
@@ -34,6 +35,7 @@ You can get all of the comments on a file by calling
 `FilesManager.GetCommentsAsync(string id, IEnumerable<string> fields = null)`
 with the ID of the file.
 
+<!-- sample get_comments_id -->
 ```c#
 string fileId = "11111";
 BoxCollection<BoxComment> comments = await client.FilesManager.GetCommentsAsync(fileId);
@@ -45,6 +47,7 @@ Add a Comment to a File
 A comment can be added to a file by calling
 `CommentsManager.AddCommentAsync(BoxCommentRequest commentRequest, IEnumerable<string> fields = null)`.
 
+<!-- sample post_comments -->
 ```c#
 var requestParams = new BoxCommentRequest()
 {
@@ -65,6 +68,7 @@ The message of a comment can be changed by calling
 `CommentsManager.UpdateAsync(string id, BoxCommentRequest commentsRequest, IEnumerable<string> fields = null)`
 with the ID of the comment and the fields to update.
 
+<!-- sample put_comments_id -->
 ```c#
 var requestParams = new BoxCommentRequest()
 {
@@ -78,6 +82,7 @@ Delete a Comment
 
 A comment can be deleted by calling `CommentsManager.DeleteAsync(string id)` with the ID of the comment.
 
+<!-- sample delete_comments_id -->
 ```c#
 await client.CommentsManager.DeleteAsync(id: "11111");
 ```

--- a/docs/device-pins.md
+++ b/docs/device-pins.md
@@ -21,6 +21,7 @@ Get Enterprise Device Pins
 Get all device pins records for an enterprise by calling
 `DevicePinManager.GetEnterpriseDevicePinsAsync(string enterpriseId, string marker = null, int limit = 100, BoxSortDirection direction = BoxSortDirection.ASC, bool autoPaginate = false)`.
 
+<!-- sample get_enterprises_id_device_pinners -->
 ```c#
 BoxCollectionMarkerBased<BoxDevicePin> pins = await client.DevicePinManager
     .GetEnterpriseDevicePinsAsync(enterpriseId: "12345");
@@ -32,6 +33,7 @@ Get Device Pin
 To get information about a specific device pin, call `DevicePinManager.GetDevicePin(string id)`
 with the ID of the device pin object.
 
+<!-- sample get_device_pinners_id -->
 ```c#
 BoxDevicePin pin = await client.DevicePinManager.GetDevicePin(id: "11111");
 ```
@@ -42,6 +44,7 @@ Delete Device Pin
 To remove a specific device pin, call `DevicePinManager.DeleteDevicePin(string id)` with the ID of the device
 pin to delete.
 
+<!-- sample delete_device_pinners_id -->
 ```c#
 await client.DevicePinManager.DeleteDevicePin(id: "11111");
 ```

--- a/docs/files.md
+++ b/docs/files.md
@@ -37,6 +37,7 @@ To get information about a specific file, call
 `FilesManager.GetInformationAsync(string id, IEnumerable<string> fields = null)` with the
 ID of the file.
 
+<!-- sample get_files_id -->
 ```c#
 BoxFile file = await client.FilesManager.GetInformationAsync(id: "11111");
 ```
@@ -48,6 +49,7 @@ Updating a file's information is done by calling
 `FilesManager.UpdateInformationAsync(BoxFileRequest fileRequest, string etag = null, IEnumerable<string> fields = null)`
 with the fields of the file object to update.
 
+<!-- sample put_files_id -->
 ```c#
 // Rename file 11111
 var requestParams = new BoxFileRequest()
@@ -65,6 +67,7 @@ A file can be downloaded by calling
 `FilesManager.DownloadStreamAsync(string id, string versionId = null, TimeSpan? timeout = null, int? startOffsetInBytes = null, int? endOffsetInBytes = null)`,
 which provides a `Stream` that will yield the file's contents.
 
+<!-- sample get_files_id_content -->
 ```c#
 Stream fileContents = await client.FilesManager.DownloadStreamAsync(id: "11111");
 ```
@@ -87,6 +90,7 @@ The simplest way to upload a file to a folder is by calling
 `FilesManager.UploadAsync(BoxFileRequest fileRequest, Stream stream, IEnumerable<string> fields = null, TimeSpan? timeout = null, byte[] contentMD5 = null, bool setStreamPositionToZero = true, Uri uploadUri = null)`
 with the upload parameters and a stream of the file contents to upload.
 
+<!-- sample post_files_id_content -->
 ```c#
 using (FileStream fileStream = new FileStream(filePath, FileMode.Open))
 {
@@ -107,6 +111,7 @@ A file can be copied to a new folder with the
 `FilesManager.CopyAsync(BoxFileRequest fileRequest, IEnumerable<string> fields = null)`
 method.
 
+<!-- sample post_files_id_copy -->
 ```c#
 string fileId = "11111";
 string destinationFolderId = "22222";
@@ -129,6 +134,7 @@ Calling the
 `FilesManager.DeleteAsync(string id, string etag = null)`
 method will move the file to the user's trash.
 
+<!-- sample delete_files_id -->
 ```c#
 await client.FilesManager.DeleteAsync(id: "11111");
 ```
@@ -140,6 +146,7 @@ Retrieve a list of previous versions of a file by calling
 `FilesManager.ViewVersionsAsync(string id, IEnumerable<string> fields = null)`
 with the ID of the file.
 
+<!-- sample get_files_id_versions -->
 ```c#
 BoxCollection<BoxFileVersion> previousVersions = await client.FilesManager
     .ViewVersionsAsync(id: "11111");
@@ -152,6 +159,7 @@ A new version of a file can be uploaded by calling
 `FilesManager.UploadNewVersionAsync(string fileName, string fileId, Stream stream, string etag = null, IEnumerable<string> fields = null, TimeSpan? timeout = null, byte[] contentMD5 = null, bool setStreamPositionToZero = true, Uri uploadUri = null)`
 with the name and ID of the file, and a `Stream` of the new contents of the file.
 
+<!-- sample post_files_id_content -->
 ```c#
 using (FileStream fileStream = new FileStream(filePath, FileMode.Open))
 {
@@ -180,6 +188,7 @@ Promote file version to the top of the stack by calling `FilesManager.PromoteVer
 with the ID of the file and the ID of the version to make the current version.  This will create a new file version with
 the same contents as the previous version, as the current version.
 
+<!-- sample post_files_id_versions_current -->
 ```c#
 string fileId = "11111";
 BoxFileVersion current = await client.FilesManager.PromoteVersionAsync(fileId, versionId: "22222");
@@ -192,6 +201,7 @@ An old version of a file can be moved to the trash by calling
 `FilesManager.DeleteOldVersionAsync(string id, string versionId, string etag = null)`
 with the ID of the file and the ID of the file version to delete.
 
+<!-- sample delete_files_id_versions_id -->
 ```c#
 string fileId = "11111";
 await client.FilesManager.DeleteOldVersionAsync(fileId, versionId: "22222");

--- a/docs/files.md
+++ b/docs/files.md
@@ -90,7 +90,7 @@ The simplest way to upload a file to a folder is by calling
 `FilesManager.UploadAsync(BoxFileRequest fileRequest, Stream stream, IEnumerable<string> fields = null, TimeSpan? timeout = null, byte[] contentMD5 = null, bool setStreamPositionToZero = true, Uri uploadUri = null)`
 with the upload parameters and a stream of the file contents to upload.
 
-<!-- sample post_files_id_content -->
+<!-- sample post_files_content -->
 ```c#
 using (FileStream fileStream = new FileStream(filePath, FileMode.Open))
 {

--- a/docs/groups.md
+++ b/docs/groups.md
@@ -29,6 +29,7 @@ To create a new group, call
 `GroupsManager.CreateAsync(BoxGroupRequest groupRequest, IEnumerable<string> fields = null)`
 with the parameters for the group being created.
 
+<!-- sample post_groups -->
 ```c#
 var groupParams = new BoxGroupRequest()
 {
@@ -44,6 +45,7 @@ To retrieve the information for a group, call
 `GroupsManager.GetGroupAsync(string id, IEnumerable<string> fields = null)`
 with the ID of the group.
 
+<!-- sample get_groups_id -->
 ```c#
 BoxGroup group = await client.GroupsManager.GetGroupAsync("11111");
 ```
@@ -55,6 +57,7 @@ To get a list of all groups in the calling user's enterprise, call
 `GroupsManager.GetAllGroupsAsync(int? limit = null, int? offset = null, IEnumerable<string> fields = null, bool autoPaginate = false)`.
 Note that this requires permission to view an enterprise's groups, which is reserved for enterprise administrators.
 
+<!-- sample get_groups -->
 ```c#
 BoxCollection<BoxGroup> groups = await client.GroupsManager.GetAllGroupsAsync();
 ```
@@ -66,6 +69,7 @@ To change the properties of a group object, call the
 `GroupsManager.UpdateAsync(string id, BoxGroupRequest groupRequest, IEnumerable<string> fields = null)`
 method with the set of properties to update.
 
+<!-- sample put_groups_id -->
 ```c#
 var updates = new BoxGroupRequest()
 {
@@ -79,6 +83,7 @@ Delete Group
 
 To delete a group, call `(string id)` with the ID of the group to delete.
 
+<!-- sample delete_groups_id -->
 ```c#
 await client.GroupsManager.DeleteAsync("11111");
 ```
@@ -91,6 +96,7 @@ access to, call
 `GroupsManager.GetCollaborationsForGroupAsync(string groupId, int? limit = null, int? offset = null, IEnumerable<string> fields = null, bool autoPaginate = false)`
 with the ID of the group.
 
+<!-- sample get_groups_id_collaborations -->
 ```c#
 BoxCollection<BoxCollaboration> groupCollaborations = await client.GroupsManager
     .GetCollaborationsForGroupAsync(groupId: "11111");
@@ -102,6 +108,7 @@ Add a User to a Group
 To add a user to a group, call
 `GroupsManager.AddMemberToGroupAsync(BoxGroupMembershipRequest membershipRequest, IEnumerable<string> fields = null)`.
 
+<!-- sample post_group_memberships -->
 ```c#
 var requestParams = new BoxGroupMembershipRequest()
 {
@@ -133,6 +140,7 @@ To update a membership record, call
 `GroupsManager.UpdateGroupMembershipAsync(string membershipId, BoxGroupMembershipRequest memRequest, IEnumerable<string> fields = null)`
 with the ID of the membership object and the fields to update.
 
+<!-- sample put_group_memberships_id -->
 ```c#
 var updates = new BoxGroupMembershipRequest()
 {
@@ -148,6 +156,7 @@ Remove Membership
 To remove a specific membership record, which removes a user from the group, call the
 `GroupsManager.DeleteGroupMembershipAsync(string id)` method with the ID of the membership record to remove.
 
+<!-- sample delete_group_memberships_id -->
 ```c#
 await client.GroupsManager.DeleteGroupMembershipAsync("33333");
 ```
@@ -159,6 +168,7 @@ To get a list of all memberships to a group, call the
 `GroupsManager.GetAllGroupMembershipsForGroupAsync(string groupId, int? limit = null, int? offset = null, IEnumerable<string> fields = null, bool autoPaginate = false)`
 method with the ID of the group to get the list of memberships for.
 
+<!-- sample get_groups_id_memberships -->
 ```c#
 BoxCollection<BoxGroupMembership> memberships = await client.GroupsManager
     .GetAllGroupMembershipsForGroupAsync("11111");
@@ -172,6 +182,7 @@ To get a list of groups to which a user belongs, call the
 method.  Note that this method requires the calling user to have permission to
 view groups, which is restricted to enterprise administrators.
 
+<!-- sample get_users_id_memberships -->
 ```c#
 BoxCollection<BoxGroupMembership> memberships = await client.GroupsManager
     .GetAllGroupMembershipsForUserAsync(userId: "11111");

--- a/docs/legal-holds.md
+++ b/docs/legal-holds.md
@@ -30,6 +30,7 @@ To retrieve information about a specific legal hold policy, call
 `LegalHoldPoliciesManager.GetLegalHoldPolicyAsync(string legalHoldId)`
 with the ID of the legal hold policy.
 
+<!-- sample get_legal_hold_policies_id -->
 ```c#
 BoxLegalHoldPolicy policy = await client.LegalHoldPoliciesManager.GetLegalHoldPolicyAsync("11111");
 ```
@@ -40,6 +41,7 @@ Get Enterprise Legal Hold Policies
 To retrieve all of the legal hold policies for the given enterprise, call
 `LegalHoldPoliciesManager.GetListLegalHoldPoliciesAsync(string policyName = null, string fields = null, int limit = 100, string marker = null, bool autoPaginate = false)`.
 
+<!-- sample get_legal_hold_policies -->
 ```c#
 BoxCollectionMarkerBased<BoxLegalHoldPolicy> policies = await client.LegalHoldPoliciesManager
     .GetListLegalHoldPoliciesAsync();
@@ -51,6 +53,7 @@ Create Legal Hold Policy
 To create a new legal hold policy, call
 `LegalHoldPoliciesManager.CreateLegalHoldPolicyAsync(BoxLegalHoldPolicyRequest createRequest)`.
 
+<!-- sample post_legal_hold_policies -->
 ```c#
 var policyParams = new BoxLegalHoldPolicyRequest()
 {
@@ -67,6 +70,7 @@ To update or modify an existing legal hold policy, call
 `LegalHoldPoliciesManager.UpdateLegalHoldPolicyAsync(string legalHoldPolicyId, BoxLegalHoldPolicyRequest updateRequest)`
 with the ID of the policy to update and the fields to update.
 
+<!-- sample put_legal_hold_policies_id -->
 ```c#
 var updates = new BoxLegalHoldPolicyRequest()
 {
@@ -84,6 +88,7 @@ To delete a legal hold policy, call
 Note that this is an asynchronous process - the policy will not be fully deleted
 yet when the response comes back.
 
+<!-- sample delete_legal_hold_policies_id -->
 ```c#
 await client.LegalHoldPoliciesManager.DeleteLegalHoldPolicyAsync("11111");
 ```
@@ -94,6 +99,7 @@ Get Legal Hold Policy Assignment
 To retrieve information about a legal hold policy assignment, call
 `LegalHoldPoliciesManager.GetAssignmentAsync(string assignmentId)` with the ID of the assignment object.
 
+<!-- sample get_legal_hold_policy_assignments_id -->
 ```c#
 BoxLegalHoldPolicyAssignment assignment = await client.LegalHoldPoliciesManager
     .GetAssignmentAsync(assignmentId: "22222");
@@ -106,6 +112,7 @@ To get a list of all legal hold policy assignments associated with a specified l
 `LegalHoldPoliciesManager.GetAssignmentsAsync(string legalHoldPolicyId, string fields = null, string assignToType = null, string assignToId = null, int limit = 100, string marker = null, bool autoPaginate = false)`
 with the ID of the policy.
 
+<!-- sample get_legal_hold_policy_assignments -->
 ```c#
 BoxCollectionMarkerBased<BoxLegalHoldPolicyAssignment> assignments = await client.LegalHoldPoliciesManager
     .GetAssignmentsAsync(legalHoldPolicyId: "11111");
@@ -117,6 +124,7 @@ Assign Legal Hold Policy
 To assign a legal hold policy, call
 `LegalHoldPoliciesManager.CreateAssignmentAsync(BoxLegalHoldPolicyAssignmentRequest createRequest)`.
 
+<!-- sample post_legal_hold_policy_assignments -->
 ```c#
 var requestParams = new BoxLegalHoldPolicyAssignmentRequest()
 {
@@ -139,6 +147,7 @@ To delete a legal hold assignment and remove a legal hold policy from an item, c
 method.  Note that this is an asynchronous process - the assignment will not be fully deleted
 yet when the response comes back.
 
+<!-- sample delete_legal_hold_policy_assignments_id -->
 ```c#
 await client.LegalHoldPoliciesManager.DeleteAssignmentAsync("22222");
 ```
@@ -151,6 +160,7 @@ for a specific file version legal hold record, call
 `LegalHoldPoliciesManager.GetFileVersionLegalHoldAsync(string fileVersionLegalHoldId)`
 with the ID of the file version legal hold record.
 
+<!-- sample get_file_version_legal_holds_id -->
 ```c#
 BoxFileVersionLegalHold hold = await client.LegalHoldPoliciesManager
     .GetFileVersionLegalHoldAsync("55555");
@@ -163,6 +173,7 @@ To retrieve a list of all file version legal holds for a given policy, call
 `LegalHoldPoliciesManager.GetFileVersionLegalHoldsAsync(string policyId, IEnumerable<string> fields = null, int limit = 100, string marker = null, bool autoPaginate = false)`
 with the ID of the legal hold policy.
 
+<!-- sample get_file_version_legal_holds -->
 ```c#
 BoxCollectionMarkerBased<BoxFileVersionLegalHold> holds = await client.LegalHoldPoliciesManager
     .GetFileVersionLegalHoldsAsync(policyId: "11111");

--- a/docs/metadata-cascade-policies.md
+++ b/docs/metadata-cascade-policies.md
@@ -25,6 +25,7 @@ Create Metadata Cascade Policy
 To create a new metadata cascade policy, call
 `MetadataCascadePolicyManager.CreateCascadePolicyAsync(string folderId, string scope, string templateKey)`.
 
+<!-- sample post_metadata_cascade_policies -->
 ```c#
 BoxMetadataCascadePolicy metadataCascadePolicy = await client.MetadataCascadePolicyManager
     .CreateCascadePolicyAsync("22222", "enterprise_11111", "templateKey");
@@ -36,6 +37,7 @@ Get a Metadata Cascade Policy
 To get information about a specific metadata cascade policy, call
 `MetadataCascadePolicyManager.GetCascadePolicyAsync(string policyId)`
 
+<!-- sample get_metadata_cascade_policies_id -->
 ```c#
 BoxMetadataCascadePolicy retrievedCascadePolicy = await client.MetadataCascadePolicyManager
     .GetCascadePolicyAsync("12345", IEnumerable<string> fields = null);
@@ -47,6 +49,7 @@ Get Metadata Cascade Policies for Folder
 To retrieve a collection of metadata cascade policies within a given folder for the current enterprise, use
 `MetadataCascadePolicyManager.GetAllMetadataCascadePoliciesAsync(string folderId, string ownerEnterpriseId = null, int limit = 100, string nextMarker = null, IEnumerable<string> fields = null, bool autopaginate = false)`
 
+<!-- sample post_metadata_cascade_policies -->
 ```c#
 BoxCollectionMarkerBased<BoxMetadataCascadePolicy> metadataCascadePolicies = await client.MetadataCascadePolicyManager.GetAllMetadataCascadePoliciesAsync("12345");
 ```
@@ -54,6 +57,7 @@ BoxCollectionMarkerBased<BoxMetadataCascadePolicy> metadataCascadePolicies = awa
 You can also retrieve metadata cascade policies for another enterprise with specific fields to retrieve by using
 `MetadataCascadePolicyManager.GetAllMetadataCascadePoliciesAsync(string folderId, string ownerEnterpriseId, int limit, IEnumberable<string> fields)`
 
+<!-- sample get_metadata_cascade_policies -->
 ```c#
 string folderId = "1111";
 string ownerEnterpriseId = "2222";
@@ -66,6 +70,7 @@ Force Apply Metadata Cascade Policy
 To apply a policy on a folder that already has one, use
 `MetadataCascadePolicyManager.ForceApplyCascadePolicyAsync(string policyId, string conflictResolution)`
 
+<!-- sample post_metadata_cascade_policies_id_apply -->
 ```c#
 string policyId = "11111";
 string conflictResolution = Constants.ConflictResolution.Overwrite

--- a/docs/metadata-cascade-policies.md
+++ b/docs/metadata-cascade-policies.md
@@ -49,7 +49,7 @@ Get Metadata Cascade Policies for Folder
 To retrieve a collection of metadata cascade policies within a given folder for the current enterprise, use
 `MetadataCascadePolicyManager.GetAllMetadataCascadePoliciesAsync(string folderId, string ownerEnterpriseId = null, int limit = 100, string nextMarker = null, IEnumerable<string> fields = null, bool autopaginate = false)`
 
-<!-- sample post_metadata_cascade_policies -->
+<!-- sample get_metadata_cascade_policies -->
 ```c#
 BoxCollectionMarkerBased<BoxMetadataCascadePolicy> metadataCascadePolicies = await client.MetadataCascadePolicyManager.GetAllMetadataCascadePoliciesAsync("12345");
 ```
@@ -57,7 +57,6 @@ BoxCollectionMarkerBased<BoxMetadataCascadePolicy> metadataCascadePolicies = awa
 You can also retrieve metadata cascade policies for another enterprise with specific fields to retrieve by using
 `MetadataCascadePolicyManager.GetAllMetadataCascadePoliciesAsync(string folderId, string ownerEnterpriseId, int limit, IEnumberable<string> fields)`
 
-<!-- sample get_metadata_cascade_policies -->
 ```c#
 string folderId = "1111";
 string ownerEnterpriseId = "2222";

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -46,6 +46,7 @@ Create Metadata Template
 To create a new metadata template, call
 `MetadataManager.CreateMetadataTemplate(BoxMetadataTemplate template)`.
 
+<!-- sample post_metadata_templates_schema -->
 ```c#
 var templateParams = new BoxMetadataTemplate()
 {
@@ -85,6 +86,7 @@ method with the operations to perform on the template.  See the
 [API Documentation](https://docs.box.com/reference#update-metadata-schema)
 for more information on the operations available.
 
+<!-- sample put_metadata_templates_id_id_schema -->
 ```c#
 var updates = new List<BoxMetadataTemplateUpdate>()
 {
@@ -117,6 +119,7 @@ To retrieve a specific metadata template by its scope and template key, call the
 `MetadataManager.GetMetadataTemplate(string scope, string template)`
 method with the scope and template key.
 
+<!-- sample get_metadata_templates_id_id_schema -->
 ```c#
 BoxMetadataTemplate template = await client.MetadataManager
     .GetMetadataTemplate("enterprise", "marketingCollateral");
@@ -128,6 +131,7 @@ To get a specific metadata template by its ID, call the
 `MetadataManager.GetMetadataTemplateById(string templateId)`
 method with the ID of the template.
 
+<!-- sample get_metadata_templates_id -->
 ```c#
 BoxMetadataTemplate template = await client.MetadataManager
     .GetMetadataTemplateById("17f2d715-6acb-45f2-b96a-28b15efc9faa");
@@ -139,6 +143,7 @@ Get Enterprise Metadata Templates
 Get all metadata templates for the current enterprise and scope by calling
 `MetadataManager.GetEnterpriseMetadataAsync(string scope = "enterprise")`.
 
+<!-- sample get_metadata_templates_enterprise -->
 ```c#
 BoxEnterpriseMetadataTemplateCollection<BoxMetadataTemplate> templates = await client.MetadataManager
     .GetEnterpriseMetadataAsync();
@@ -177,6 +182,7 @@ with a metadata template and a `Dictionary` of key/value pairs to add as metadat
 > __Note:__: This method will only succeed if the provided metadata template is not current applied to the file,
 > otherwise it will fail with a Conflict error.
 
+<!-- sample post_files_id_metadata_id_id -->
 ```c#
 var metadataValues = new Dictionary<string, object>()
 {
@@ -200,6 +206,7 @@ with a list of update operations to apply.
 > This is useful in cases where you know the file will already have metadata applied, since it will
 > save an API call compared to `SetFileMetadataAsync()`.
 
+<!-- sample put_files_id_metadata_id_id -->
 ```c#
 var updates = new List<BoxMetadataUpdate>()
 {
@@ -268,6 +275,7 @@ Retrieve a specific metadata template on a file by calling
 `MetadataManager.GetFileMetadataAsync(string fileId, string scope, string template)`
 with the ID of the file and which template to fetch.
 
+<!-- sample get_files_id_metadata_id_id -->
 ```c#
 Dictionary<string, object> metadata = await client.MetadataManager.
     .GetFileMetadataAsync(fileId: "11111", "enterprise", "marketingCollateral");
@@ -275,6 +283,7 @@ Dictionary<string, object> metadata = await client.MetadataManager.
 
 You can also get all metadata on a file by calling `MetadataManager.GetAllFileMetadataTemplatesAsync(string fileId)`.
 
+<!-- sample get_files_id_metadata -->
 ```c#
 BoxMetadataTemplateCollection<Dictionary<string, object>> metadataInstances = await client.MetadataManager
     .GetAllFileMetadataTemplatesAsync(fileId: "11111");
@@ -287,6 +296,7 @@ A metadata template can be removed from a file by calling
 `MetadataManager.DeleteFileMetadataAsync(string fileId, string scope, string template)`
 with the ID of the file and the metadata template to remove.
 
+<!-- sample delete_files_id_metadata_id_id -->
 ```c#
 await client.MetadataManager.DeleteFileMetadataAsync("11111", "enterprise", "marketingCollateral");
 ```
@@ -324,6 +334,7 @@ with a metadata template and a `Dictionary` of key/value pairs to add as metadat
 > __Note:__: This method will only succeed if the provided metadata template is not current applied to the folder,
 > otherwise it will fail with a Conflict error.
 
+<!-- sample post_folders_id_metadata_id_id -->
 ```c#
 var metadataValues = new Dictionary<string, object>()
 {
@@ -347,6 +358,7 @@ with a list of update operations to apply.
 > This is useful in cases where you know the folder will already have metadata applied, since it will
 > save an API call compared to `SetFolderMetadataAsync()`.
 
+<!-- sample put_folders_id_metadata_id_id -->
 ```c#
 var updates = new List<BoxMetadataUpdate>()
 {
@@ -415,6 +427,7 @@ Retrieve a specific metadata template on a folder by calling
 `MetadataManager.GetFolderMetadataAsync(string folderId, string scope, string template)`
 with the ID of the folder and which template to fetch.
 
+<!-- sample get_folders_id_metadata_id_id -->
 ```c#
 Dictionary<string, object> metadata = await client.MetadataManager.
     .GetFolderMetadataAsync(folderId: "11111", "enterprise", "marketingCollateral");
@@ -423,6 +436,7 @@ Dictionary<string, object> metadata = await client.MetadataManager.
 You can also get all metadata on a folder by calling
 `MetadataManager.GetAllFolderMetadataTemplatesAsync(string folderId)`.
 
+<!-- sample post_folders_id_metadata -->
 ```c#
 BoxMetadataTemplateCollection<Dictionary<string, object>> metadataInstances = await client.MetadataManager
     .GetAllFolderMetadataTemplatesAsync(folderId: "11111");
@@ -435,6 +449,7 @@ A metadata template can be removed from a folder by calling
 `MetadataManager.DeleteFolderMetadataAsync(string folderId, string scope, string template)`
 with the ID of the folder and the metadata template to remove.
 
+<!-- sample delete_folders_id_metadata_id_id -->
 ```c#
 await client.MetadataManager.DeleteFolderMetadataAsync("11111", "enterprise", "marketingCollateral");
 ```

--- a/docs/recent-items.md
+++ b/docs/recent-items.md
@@ -18,6 +18,7 @@ Get a User's Recent Items
 Get a list of all recent items the user has by calling
 `GetRecentItemsAsync(int limit = 100, string marker = null, IEnumerable<string> fields = null, bool autoPaginate = false)`.
 
+<!-- sample get_recent_items -->
 ```c#
 BoxCollectionMarkerBasedV2<BoxRecentItem> recentItems = await client.RecentItemsManager
     .GetRecentItemsAsync(limit: 500);

--- a/docs/retention-policies.md
+++ b/docs/retention-policies.md
@@ -29,6 +29,7 @@ To create a new retention policy, call
 `RetentionPoliciesManager.CreateRetentionPolicyAsync(BoxRetentionPolicyRequest retentionPolicyRequest)`
 with the parameters for the new retention policy.
 
+<!-- sample post_retention_policies -->
 ```c#
 var policyParams = new BoxRetentionPolicyRequest()
 {
@@ -48,6 +49,7 @@ To retrieve information about a specific retention policy, call
 `RetentionPoliciesManager.GetRetentionPolicyAsync(string id, IEnumerable<string> fields = null)`
 with the ID of the policy.
 
+<!-- sample get_retention_policies_id -->
 ```c#
 BoxRetentionPolicy policy = await client.RetentionPoliciesManager.GetRetentionPolicyAsync("11111");
 ```
@@ -59,6 +61,7 @@ To update or modify an existing retention policy, call
 `RetentionPoliciesManager.UpdateRetentionPolicyAsync(string id, BoxRetentionPolicyRequest retentionPolicyRequest, IEnumerable<string> fields = null)`
 with the ID of the policy to update and the set of fields to update.
 
+<!-- sample put_retention_policies_id -->
 ```c#
 var updates = new BoxRetentionPolicyRequest()
 {
@@ -74,6 +77,7 @@ Get Enterprise Retention Policies
 To retrieve all of the retention policies for the given enterprise, call
 `RetentionPoliciesManager.GetRetentionPoliciesAsync(string policyName = null, string policyType = null, string createdByUserId = null, IEnumerable<string> fields = null, int limit = 100, string marker = null, bool autoPaginate = false)`.
 
+<!-- sample get_retention_policies -->
 ```c#
 BoxCollectionMarkerBased<BoxRetentionPolicy> policies = await client.RetentionPoliciesManager
     .GetRetentionPoliciesAsync();
@@ -86,6 +90,7 @@ To get a list of all retention policy assignments associated with a specified re
 `RetentionPoliciesManager.GetRetentionPolicyAssignmentsAsync(string retentionPolicyId, string type = null, IEnumerable<string> fields = null, int limit = 100, string marker = null, bool autoPaginate = false)`
 with the ID of the policy to get asisgnments for.
 
+<!-- sample get_retention_policies_id_assignments -->
 ```c#
 BoxCollectionMarkerBased<BoxRetentionPolicyAssignment> assignments = await client.RetentionPoliciesManager
     .GetRetentionPolicyAssignmentsAsync(retentionPolicyId: "11111");
@@ -98,6 +103,7 @@ To assign a retention policy, call
 `RetentionPoliciesManager.CreateRetentionPolicyAssignmentAsync(BoxRetentionPolicyAssignmentRequest policyAssignmentRequest, IEnumerable<string> fields = null)`
 with the parameters of the assignment.
 
+<!-- sample post_retention_policy_assignments -->
 ```c#
 var assignmentParams = new BoxRetentionPolicyAssignmentRequest()
 {
@@ -119,6 +125,7 @@ To retrieve information about a retention policy assignment, call
 `RetentionPoliciesManager.GetRetentionPolicyAssignmentAsync(string retentionPolicyAssignmentId, IEnumerable<string> fields = null)`
 with the ID of the assignment.
 
+<!-- sample get_retention_policy_assignments_id -->
 ```c#
 BoxRetentionPolicyAssignment assignment = await client.RetentionPoliciesManager
     .GetRetentionPolicyAssignmentAsync("33333");
@@ -132,6 +139,7 @@ for a specific file version retention record, call the
 `RetentionPoliciesManager.GetFileVersionRetentionAsync(string fileVersionRetentionId, IEnumerable<string> fields = null)`
 method with the ID of the retention object.
 
+<!-- sample get_file_version_retentions_id -->
 ```c#
 BoxFileVersionRetention retention = await client.RetentionPoliciesManager
     .GetFileVersionRetentionAsync("55555");
@@ -144,6 +152,7 @@ To retrieve a list of all file version retentions for the given enterprise or to
 some category of file version retention records, call
 `RetentionPoliciesManager.GetFileVersionRetentionsAsync(IEnumerable<string> fields = null, int limit = 100, string marker = null, bool autoPaginate = false)`.
 
+<!-- sample get_file_version_retentions -->
 ```c#
 BoxCollectionMarkerBased<BoxFileVersionRetention> retentions = await client.RetentionPoliciesManager
     .GetFileVersionRetentionsAsync();

--- a/docs/search.md
+++ b/docs/search.md
@@ -36,6 +36,7 @@ SearchManager.SearchAsync(string keyword = null,
 method.  There are many possible options for advanced search filtering, which are
 documented in the [Search API Reference](https://docs.box.com/reference#searching-for-content).
 
+<!-- sample get_search -->
 ```c#
 // Search for PDF or Word documents matching "Meeting Notes"
 BoxCollection<BoxItem> results = await client.SearchManager

--- a/docs/storage-policies.md
+++ b/docs/storage-policies.md
@@ -12,6 +12,7 @@ To get a list of the storage policies that are available for the current user's 
 `StoragePoliciesManager.GetListStoragePoliciesAsync(string fields = null, string marker = null, int limit = 100, bool autoPaginate = false)`
 method.
 
+<!-- sample get_storage_policies -->
 ```c#
 BoxCollectionMarkerBased<BoxStoragePolicy> policies = await client.StoragePoliciesManager
     .GetListStoragePoliciesAsync();
@@ -25,6 +26,7 @@ Information about a specific storage policy (by its ID) can be retrieved by call
 the `StoragePoliciesManager.GetStoragePolicyAsync(String policyId)` method with the ID of
 the storage policy to retrieve.
 
+<!-- sample get_storage_policies_id -->
 ```c#
 BoxStoragePolicy policy = await client.StoragePoliciesManager.GetStoragePolicyAsync(policyId: "6");
 ```
@@ -39,6 +41,7 @@ method with the ID of the storage policy to assign and the ID of the user to whi
 > __Note:__ This method will check if an assignment already exists for the user and take appropriate action.
 > It should work regardless of the current status of the user.
 
+<!-- sample post_storage_policy_assignments -->
 ```c#
 BoxStoragePolicyAssignment assignment = await client.StoragePoliciesManager
     .AssignAsync(userId: "22222", storagePolicyId: "6");
@@ -51,6 +54,7 @@ To get information about a specific storage policy assignment by ID, call the
 `StoragePoliciesManager.GetAssignmentAsync(string assignmentId)` method
 with the ID of the storage policy assignment.
 
+<!-- sample get_storage_policy_assignments_id -->
 ```c#
 BoxStoragePolicyAssignment assignment = await client.StoragePoliciesManager
     .GetAssignmentAsync(assignmentId: "dXNlcl8yMjIyMg==");
@@ -63,6 +67,7 @@ To determine which storage policy is assigned to a user, call
 `StoragePoliciesManager.GetAssignmentForTargetAsync(string entityId, string entityType = "user")`
 with the ID of the user.
 
+<!-- sample get_storage_policy_assignments -->
 ```c#
 BoxStoragePolicyAssignment assignment = client.StoragePoliciesManager
     .GetAssignmentForTargetAsync("22222");
@@ -79,6 +84,7 @@ with the ID of the storage policy to assign and the ID of the user to assign it 
 > If the current state of the user is not known, use the [`AssignAsync()`](#assign-a-storage-policy-to-a-user)
 > method instead.
 
+<!-- sample post_storage_policy_assignments -->
 ```c#
 BoxStoragePolicyAssignment assignment = client.StoragePoliciesManager
     .CreateAssignmentAsync(userId: "22222", policyId: "6");
@@ -91,6 +97,7 @@ To update a storage policy assignment, for example to update which storage polic
 asisgned to a user, call the `StoragePoliciesManager.UpdateStoragePolicyAssignment(string assignmentId, String policyId)`
 method with the ID of the assignment to update and the new policy ID to assign.
 
+<!-- sample put_storage_policy_assignments -->
 ```c#
 // Reassign user 1234 to storage policy 7
 BoxStoragePolicyAssignment assignment = await client.StoragePoliciesManager
@@ -105,6 +112,7 @@ default storage policy for the enterprise, call
 `StoragePoliciesManager.DeleteAssignmentAsync(string assignmentId)` with
 the ID of the assignment to remove.
 
+<!-- sample delete_storage_policy_assignments -->
 ```c#
 await client.StoragePoliciesManager.DeleteAssignmentAsync(assignmentId: "dXNlcl8yMjIyMg==");
 ```

--- a/docs/storage-policies.md
+++ b/docs/storage-policies.md
@@ -41,7 +41,6 @@ method with the ID of the storage policy to assign and the ID of the user to whi
 > __Note:__ This method will check if an assignment already exists for the user and take appropriate action.
 > It should work regardless of the current status of the user.
 
-<!-- sample post_storage_policy_assignments -->
 ```c#
 BoxStoragePolicyAssignment assignment = await client.StoragePoliciesManager
     .AssignAsync(userId: "22222", storagePolicyId: "6");
@@ -97,7 +96,7 @@ To update a storage policy assignment, for example to update which storage polic
 asisgned to a user, call the `StoragePoliciesManager.UpdateStoragePolicyAssignment(string assignmentId, String policyId)`
 method with the ID of the assignment to update and the new policy ID to assign.
 
-<!-- sample put_storage_policy_assignments -->
+<!-- sample put_storage_policy_assignments_id -->
 ```c#
 // Reassign user 1234 to storage policy 7
 BoxStoragePolicyAssignment assignment = await client.StoragePoliciesManager

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -108,7 +108,7 @@ To assign a task to a user, call
 with the ID of the task to assign and either the ID or login email address of the
 user to whom the task should be assigned.
 
-<!-- sample post_task_assignments_id -->
+<!-- sample post_task_assignments -->
 ```c#
 // Assign task 11111 to user 22222
 var assignmentParams = new BoxTaskAssignmentRequest()

--- a/docs/tasks.md
+++ b/docs/tasks.md
@@ -25,6 +25,7 @@ Get a Task's Information
 
 To get a task information call `TasksManager.GetTaskAsync(string taskId)` with the ID of the task.
 
+<!-- sample get_tasks_id -->
 ```c#
 BoxTask task = await client.TasksManager.GetTaskAsync("11111");
 ```
@@ -35,6 +36,7 @@ Get Tasks on a File
 Calling the `FilesManager.GetFileTasks(string id, IEnumerable<string> fields = null)`
 method will retrieve all of the tasks for the given file.
 
+<!-- sample get_files_id_tasks -->
 ```c#
 BoxCollection<BoxTask> tasks = await client.FilesManager.FilesManager.GetFileTasks("11111");
 ```
@@ -45,6 +47,8 @@ Create a Task
 To create a task, call `TasksManager.CreateTaskAsync(BoxTaskCreateRequest taskCreateRequest)` with the
 parameters of the task.
 
+
+<!-- sample post_tasks -->
 ```c#
 var taskParams = new BoxTaskCreateRequest()
 {
@@ -64,6 +68,7 @@ Update a Task
 To update a task, call
 `TasksManager.UpdateTaskAsync(BoxTaskUpdateRequest taskUpdateRequest)`.
 
+<!-- sample put_tasks_id -->
 ```c#
 var updates = new BoxTaskUpdateRequest()
 {
@@ -78,6 +83,7 @@ Delete a Task
 
 To delete a task, call the `TasksManager.DeleteTaskAsync(string taskId)` method with the ID of the task to be deleted.
 
+<!-- sample delete_tasks_id -->
 ```c#
 await client.TasksManager.DeleteTaskAsync("11111");
 ```
@@ -88,6 +94,7 @@ Get Assignments for a Task
 To get a list of assignments for a task, which associate the task to users who
 must complete it, call `TasksManager.GetAssignmentsAsync(string taskId)` with the ID of the task.
 
+<!-- sample get_tasks_id_assignments -->
 ```c#
 BoxCollection<BoxTaskAssignment> assignments = await client.TasksManager
     .GetAssignmentsAsync(taskId: "11111");
@@ -101,6 +108,7 @@ To assign a task to a user, call
 with the ID of the task to assign and either the ID or login email address of the
 user to whom the task should be assigned.
 
+<!-- sample post_task_assignments_id -->
 ```c#
 // Assign task 11111 to user 22222
 var assignmentParams = new BoxTaskAssignmentRequest()
@@ -140,6 +148,7 @@ To retrieve information about a specific task assignment, call the
 `TasksManager.GetTaskAssignmentAsync(string taskAssignmentId)`
 method with the ID of the assignment to get.
 
+<!-- sample get_task_assignments_id -->
 ```c#
 BoxTaskAssignment assignment = await client.TasksManager.GetTaskAssignmentAsync("12345");
 ```
@@ -151,6 +160,7 @@ To update a task assignment, call the
 `TasksManager.UpdateTaskAssignmentAsync(BoxTaskAssignmentUpdateRequest taskAssignmentUpdateRequest)`
 method.  This can be used to resolve or complete a task.
 
+<!-- sample put_task_assignments_id -->
 ```c#
 var requestParams = new BoxTaskAssignmentUpdateRequest()
 {
@@ -167,6 +177,7 @@ To delete a task assignment, effectively unassigning a user from the task, call 
 `TasksManager.DeleteTaskAssignmentAsync(string taskAssignmentId)`
 method with the ID of the assignment to remove.
 
+<!-- sample delete_task_assignments_id -->
 ```c#
 await client.TasksManager.DeleteTaskAssignmentAsync("12345");
 ```

--- a/docs/terms-of-service.md
+++ b/docs/terms-of-service.md
@@ -25,6 +25,7 @@ To create a terms of service call the
 `TermsOfServiceManager.CreateTermsOfServicesAsync(BoxTermsOfServicesRequest termsOfServicesRequest)`
 method with the parameters for the new terms of service.
 
+<!-- sample post_terms_of_services -->
 ```c#
 var tosParams = new CreateTermsOfServicesAsync()
 {
@@ -42,6 +43,7 @@ To update a terms of service call
 `TermsOfServiceManager.UpdateTermsOfServicesAsync(string tosId, BoxTermsOfServicesRequest termsOfServicesRequest)`
 method with the fields to update and their new values.
 
+<!-- sample put_terms_of_services_id -->
 ```c#
 var updates = new BoxTermsOfServicesRequest()
 {
@@ -59,6 +61,7 @@ To get the terms of service with an ID call
 `TermsOfServiceManager.GetTermsOfServicesByIdAsync(string tosId)`
 with the ID of the terms of service object.
 
+<!-- sample get_terms_of_services_id -->
 ```c#
 BoxTermsOfService tos = await client.TermsOfServiceManager.GetTermsOfServicesByIdAsync("11111");
 ```
@@ -69,6 +72,7 @@ Get Terms of Service for an Enterprise
 To get the terms of service for an enterprise, call
 `TermsOfServiceManager.GetTermsOfServicesAsync(string tosType = null)`.
 
+<!-- sample get_terms_of_services -->
 ```c#
 BoxTermsOfServiceCollection<BoxTermsOfService> termsOfService = await client.TermsOfServiceManager
     .GetTermsOfServicesAsync();
@@ -85,6 +89,7 @@ It is important to note that this will accept or decline a custom terms of servi
 taken action in this terms of service, this will update their status. If the user has never taken action on this terms
 of service then this will return a 404 Not Found error. 
 
+<!-- sample put_terms_of_service_user_statuses_id -->
 ```c#
 BoxTermsOfServiceUserStatuses updatedStatus = await client.TermsOfServiceManager
     .UpdateTermsofServiceUserStatusesAsync("12345", false);
@@ -98,6 +103,7 @@ To get user status on a terms of service call the
 method with the ID of the terms of service.  If no user ID is provided, the method defaults to the
 current user.
 
+<!-- sample get_terms_of_service_user_statuses_id -->
 ```c#
 BoxTermsOfServiceUserStatusesCollection<BoxTermsOfServiceUserStatuses> tosStatuses = await client.TermsOfServiceManager
     .GetTermsOfServiceUserStatusesAsync(tosId: "11111", userId: "22222");

--- a/docs/trash.md
+++ b/docs/trash.md
@@ -26,6 +26,7 @@ Get Trashed Items
 To retrieve files and folders that have been moved to the Trash, call
 `FoldersManager.GetTrashItemsAsync(int limit, int offset = 0, IEnumerable<string> fields = null, bool autoPaginate=false)`.
 
+<!-- sample get_folders_trash_items -->
 ```c#
 BoxCollection<BoxItem> trashedItems = await client.FoldersManager.GetTrashItemsAsync(limit: 100);
 ```
@@ -37,6 +38,7 @@ Information about a file in the trash can be retrieved by calling the
 `FilesManager.GetTrashedAsync(string id, IEnumerable<string> fields = null)`
 method with the ID of the file in the trash.
 
+<!-- sample get_files_id_trash -->
 ```c#
 BoxFile trashedFile = await client.FilesManager.GetTrashedAsync("11111");
 ```
@@ -48,6 +50,7 @@ Information about a folder in the trash can be retrieved by calling the
 `FoldersManager.GetTrashedFolderAsync(string id, IEnumerable<string> fields = null)`
 method with the ID of the folder in the trash.
 
+<!-- sample get_folders_id_trash -->
 ```c#
 BoxFolder trashedFolder = await client.FoldersManager.GetTrashedFolderAsync("22222");
 ```
@@ -57,6 +60,7 @@ Purge a File from the Trash
 
 Calling the `FilesManager.PurgeTrashedAsync(string id)` method will remove the file permanently from the user's trash.
 
+<!-- sample delete_files_id_trash -->
 ```c#
 await client.FilesManager.PurgeTrashedAsync("11111");
 ```
@@ -67,6 +71,7 @@ Purge a Folder from the Trash
 Calling the `FoldersManager.PurgeTrashedFolderAsync(string id)` method will remove the folder permanently from
 the user's trash.
 
+<!-- sample delete_folders_id_trash -->
 ```c#
 await client.FoldersManager.PurgeTrashedFolderAsync("22222");
 ```
@@ -82,6 +87,7 @@ folder's old location, the restored folder can be given an alternate name with
 the `Name` option.  If the folder's old location no longer exists, it can be
 placed inside a new parent folder with the `Parent.Id` option.
 
+<!-- sample post_files_id -->
 ```c#
 var requestParams = new BoxFileRequest()
 {
@@ -107,6 +113,7 @@ restored folder can be given an alternate name with the `Name` option.  If the
 folder's old location no longer exists, it can be placed inside a new parent
 folder with the `Parent.Id` option.
 
+<!-- sample post_folders_id -->
 ```c#
 var requestParams = new BoxFolderRequest()
 {

--- a/docs/users.md
+++ b/docs/users.md
@@ -28,6 +28,7 @@ Get the Current User's Information
 To get the current user call the `UsersManager.GetCurrentUserInformationAsync(IEnumerable<string> fields = null)`
 method.
 
+<!-- sample get_users_me -->
 ```c#
 BoxUser currentUser = await client.UsersManager.GetCurrentUserInformationAsync();
 ```
@@ -37,6 +38,7 @@ Get User's Information
 
 To get a user call `UsersManager.GetUserInformationAsync(string userId)` with the ID of the user.
 
+<!-- sample get_users_id -->
 ```c#
 BoxUser user = await client.UsersManager.GetUserInformationAsync(userId: "33333");
 ```
@@ -47,6 +49,7 @@ Get User Avatar
 To retrieve the avatar image for a user, call
 `UsersManager.GetUserAvatar(string userId)` with the ID of the user.
 
+<!-- sample get_users_id_avatar -->
 ```c#
 Stream imageStream = await client.UsersManager.GetUserAvatar(string userId);
 ```
@@ -58,6 +61,7 @@ To provision a new managed user within the current enterprise, call the
 `UsersManager.CreateEnterpriseUserAsync(BoxUserRequest userRequest, IEnumerable<string> fields = null)`
 method with the email address the user will use to log in and the user's name.
 
+<!-- sample post_users -->
 ```c#
 var userParams = new BoxUserRequest()
 {
@@ -91,7 +95,7 @@ To update a user's information, call
 `UsersManager.UpdateUserInformationAsync(BoxUserRequest userRequest, IEnumerable<string> fields = null)`
 with the fields to update.
 
-
+<!-- sample put_users_id -->
 ```c#
 var updates = new BoxUserRequest()
 {
@@ -110,6 +114,7 @@ To delete a user call the
 method.  If the user still has files in their account and the `force` parameter
 is not sent, an error is returned.
 
+<!-- sample delete_users_id -->
 ```c#
 await client.UsersManager.DeleteEnterpriseUserAsync("44444", notify: false, force: true);
 ```
@@ -120,6 +125,7 @@ Get Email Aliases
 To get a users email aliases, call `UsersManager.GetEmailAliasesAsync(string userId)`
 with the ID of the user.
 
+<!-- sample get_users_id_email_aliases -->
 ```c#
 BoxCollection<BoxEmailAlias> aliases = await client.UsersManager
     .GetEmailAliasesAsync(userId: "33333");
@@ -131,6 +137,7 @@ Add Email Alias
 To add an email alias for a user, call `UsersManager.AddEmailAliasAsync(string userId, string email)`
 with the ID of the user and the email address to add as an alias.
 
+<!-- sample post_users_id_email_aliases -->
 ```c#
 BoxEmailAlias alias = await client.UsersManager
     .AddEmailAliasAsync(userId: "33333", email: "user+foo@example.com");
@@ -142,6 +149,7 @@ Delete Email Alias
 To delete a users email alias, call `UsersManager.DeleteEmailAliasAsync(string userId, string emailAliasId)`
 with the ID of the user to whom the alias belongs and the ID of the email alias.
 
+<!-- sample delete_users_id_email_aliases_id -->
 ```c#
 await client.UsersManager.DeleteEmailAliasAsync(userId: "33333", emailAliasId: "12345");
 ```
@@ -153,6 +161,7 @@ Get a list of users in the current enterprise by calling the
 `UsersManager.GetEnterpriseUsersAsync(string filterTerm = null, uint offset = 0, uint limit = 100, IEnumerable<string> fields = null, string userType = null, string externalAppUserId = null, bool autoPaginate = false)`
 method.
 
+<!-- sample get_users -->
 ```c#
 BoxCollection<BoxUser> users = await client.UsersManager.GetEnterpriseUsersAsync();
 ```
@@ -166,6 +175,7 @@ method with the IDs of the source and destination users.
 
 > __Note:__ Currently, only moving the user's root folder (with ID "0") is supported.
 
+<!-- sample put_users_id_folders_id -->
 ```c#
 var sourceUserId = "33333";
 var destinationUserId = "44444";

--- a/docs/watermarking.md
+++ b/docs/watermarking.md
@@ -24,6 +24,7 @@ Get Watermark on a File
 To get watermark information for a file call the `FilesManager.GetWatermarkAsync(string id)` method
 with the ID of the file.
 
+<!-- sample get_files_id_watermark -->
 ```c#
 BoxWatermark watermark = await client.FilesManager.GetWatermarkAsync("11111");
 ```
@@ -35,6 +36,7 @@ To apply or update the watermark to a file call the
 `FilesManager.ApplyWatermarkAsync(string id, BoxApplyWatermarkRequest applyWatermarkRequest = null)`
 method with the ID of the file.
 
+<!-- sample put_files_id_watermark -->
 ```c#
 BoxWatermark watermark = await client.FilesManager.ApplyWatermarkAsync("11111");
 ```
@@ -45,6 +47,7 @@ Remove Watermark from a File
 A file's watermark can be removed by calling `FilesManager.RemoveWatermarkAsync(string id)`
 with the ID of the watermarked file.
 
+<!-- sample delete_files_id_watermark -->
 ```c#
 await client.FilesManager.RemoveWatermarkAsync("11111");
 ```
@@ -55,6 +58,7 @@ Get Watermark on a Folder
 To get watermark information for a folder call the `FoldersManager.GetWatermarkAsync(string id)` method
 with the ID of the folder.
 
+<!-- sample get_folders_id_watermark -->
 ```c#
 BoxWatermark watermark = await client.FoldersManager.GetWatermarkAsync("22222");
 ```
@@ -66,6 +70,7 @@ To apply or update the watermark for a folder call the
 `FoldersManager.ApplyWatermarkAsync(string id, BoxApplyWatermarkRequest applyWatermarkRequest = null)`
 method with the ID of the folder.
 
+<!-- sample put_folders_id_watermark -->
 ```c#
 BoxWatermark watermark = await client.FoldersManager.ApplyWatermarkAsync("22222");
 ```
@@ -76,6 +81,7 @@ Remove Watermark from a Folder
 A folder's watermark can be removed by calling `FoldersManager.RemoveWatermarkAsync(string id)`
 with the ID of the watermarked folder.
 
+<!-- sample delete_folders_id_watermark -->
 ```c#
 await client.FoldersManager.RemoveWatermarkAsync("22222");
 ```

--- a/docs/web-links.md
+++ b/docs/web-links.md
@@ -24,6 +24,7 @@ Create a Web Link
 
 To create a web link call `WebLinksManager.CreateWebLinkAsync(BoxWebLinkRequest createWebLinkRequest)`.
 
+<!-- sample post_web_links -->
 ```c#
 var weblinkParams = new BoxWebLinkRequest()
 {
@@ -42,6 +43,7 @@ Get a Web Link's information
 You can request a web link object by ID by calling `WebLinksManager.GetWebLinkAsync(string webLinkId)`
 with the ID of the web link object.
 
+<!-- sample get_web_links_id -->
 ```c#
 BoxWebLink link = await client.WebLinksManager.GetWebLinkAsync("11111");
 ```
@@ -53,6 +55,7 @@ To update a web link call the
 `WebLinksManager.UpdateWebLinkAsync(string webLinkId, BoxWebLinkRequest updateWebLinkRequest)`
 method with the fields to update and their new values.
 
+<!-- sample put_web_links_id -->
 ```c#
 var updates = new BoxWebLinkRequest()
 {

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -26,6 +26,7 @@ To attach a webhook to an item, call the
 method with the type and ID of the item, a URL to send notifications to, and a list
 of triggers.
 
+<!-- sample post_webhooks -->
 ```c#
 var webhookParams = new BoxWebhookRequest()
 {
@@ -51,6 +52,7 @@ Get a list of all webhooks for the requesting application and user by calling th
 `WebhooksManager.GetWebhooksAsync (int limit = 100, string nextMarker = null, bool autoPaginate=false)`
 method.  The maximum limit per page of results is 200, Box uses the default limit of 100.
 
+<!-- sample get_webhooks -->
 ```c#
 BoxCollectionMarkerBased<BoxWebhook> webhooks = await client.WebhooksManager.GetWebhooksAsync();
 ```
@@ -61,6 +63,7 @@ Get a Webhook"s Information
 Retrieve information about a specific webhook by calling `WebhooksManager.GetWebhookAsync(string id)`
 to retrieve a webhook by ID.
 
+<!-- sample get_webhooks_id -->
 ```c#
 BoxWebhook webhook = await client.WebhooksManager.GetWebhookAsync("12345");
 ```
@@ -104,6 +107,7 @@ Delete a Webhook
 A file or folder's webhook can be removed by calling `WebhooksManager.DeleteWebhookAsync(string id)`
 with the ID of the webhook object.
 
+<!-- sample delete_webhooks_id -->
 ```c#
 await client.WebhooksManager.DeleteWebhookAsync("11111");
 ```
@@ -114,6 +118,7 @@ Update a Webhook
 Update a file or folder's webhook by calling `WebhooksManager.UpdateWebhookAsync(BoxWebhookRequest webhookRequest)`
 with the fields of the webhook object to update.
 
+<!-- sample put_webhooks_id -->
 ```c#
 var updates = new BoxWebhookRequest()
 {


### PR DESCRIPTION
I've tagged the majority of code samples to an endpoint for usage in the new developer documentation.

