### PR TITLE
Fix date encoding in query parameters

### DIFF
--- a/Box.V2.Test/BoxSearchManagerTest.cs
+++ b/Box.V2.Test/BoxSearchManagerTest.cs
@@ -2,6 +2,7 @@ using Box.V2.Managers;
 using Box.V2.Models;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using System;
 using System.Threading.Tasks;
 
 namespace Box.V2.Test
@@ -17,6 +18,7 @@ namespace Box.V2.Test
         }
 
         [TestMethod]
+        [TestCategory("CI-UNIT-TEST")]
         public async Task SearchKeyword_ValidResponse_ValidResults()
         {
             /*** Arrange ***/
@@ -38,6 +40,56 @@ namespace Box.V2.Test
             Assert.AreEqual(4, results.TotalCount);
             Assert.AreEqual("modified_at", queryParams["sort"]);
             Assert.AreEqual("ASC", queryParams["direction"]);
+        }
+
+        [TestMethod]
+        [TestCategory("CI-UNIT-TEST")]
+        public async Task SearchWithDateRanges_ValidResponse_ValidResults()
+        {
+            /*** Arrange ***/
+            string responseString = "{\"total_count\":4,\"entries\":[{\"type\":\"file\",\"id\":\"1874102965\",\"sequence_id\":\"0\",\"etag\":\"0\",\"sha1\":\"63a112a4567fb556f5269735102a2f24f2cbea56\",\"name\":\"football.jpg\",\"description\":\"\",\"size\":260271,\"path_collection\":{\"total_count\":1,\"entries\":[{\"type\":\"folder\",\"id\":\"0\",\"sequence_id\":null,\"etag\":null,\"name\":\"All Files\"}]},\"created_at\":\"2012-03-22T18:25:07-07:00\",\"modified_at\":\"2012-10-25T14:40:05-07:00\",\"created_by\":{\"type\":\"user\",\"id\":\"175065494\",\"name\":\"Andrew Luck\",\"login\":\"aluck@colts.com\"},\"modified_by\":{\"type\":\"user\",\"id\":\"175065494\",\"name\":\"Andrew Luck\",\"login\":\"aluck@colts.com\"},\"owned_by\":{\"type\":\"user\",\"id\":\"175065494\",\"name\":\"Andrew Luck\",\"login\":\"aluck@colts.com\"},\"shared_link\":null,\"parent\":{\"type\":\"folder\",\"id\":\"0\",\"sequence_id\":null,\"etag\":null,\"name\":\"All Files\"},\"item_status\":\"active\", \"sort\":\"modified_at\", \"direction\":\"ASC\"}],\"offset\":0,\"limit\":1}";
+            IBoxRequest boxRequest = null;
+
+            Handler.Setup(h => h.ExecuteAsync<BoxCollection<BoxItem>>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxCollection<BoxItem>>>(new BoxResponse<BoxCollection<BoxItem>>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = responseString
+                }))
+                .Callback<IBoxRequest>(r => boxRequest = r);
+
+            /*** Act ***/
+            var startDate = new DateTime(1988, 11, 18, 9, 30, 0, DateTimeKind.Utc);
+            var endDate = new DateTime(2018, 11, 18, 9, 30, 0, DateTimeKind.Utc);
+            var results = await _searchManager.SearchAsync("test", createdAtRangeFromDate: startDate, createdAtRangeToDate: endDate, updatedAtRangeFromDate: startDate, updatedAtRangeToDate: endDate);
+
+            /*** Assert ***/
+            Assert.AreEqual("query=test&created_at_range=1988-11-18T09%3A30%3A00Z%2C2018-11-18T09%3A30%3A00Z&updated_at_range=1988-11-18T09%3A30%3A00Z%2C2018-11-18T09%3A30%3A00Z&limit=30&offset=0", boxRequest.GetQueryString());
+        }
+
+        [TestMethod]
+        [TestCategory("CI-UNIT-TEST")]
+        public async Task SearchWithOpenDateRanges_ValidResponse_ValidResults()
+        {
+            /*** Arrange ***/
+            string responseString = "{\"total_count\":4,\"entries\":[{\"type\":\"file\",\"id\":\"1874102965\",\"sequence_id\":\"0\",\"etag\":\"0\",\"sha1\":\"63a112a4567fb556f5269735102a2f24f2cbea56\",\"name\":\"football.jpg\",\"description\":\"\",\"size\":260271,\"path_collection\":{\"total_count\":1,\"entries\":[{\"type\":\"folder\",\"id\":\"0\",\"sequence_id\":null,\"etag\":null,\"name\":\"All Files\"}]},\"created_at\":\"2012-03-22T18:25:07-07:00\",\"modified_at\":\"2012-10-25T14:40:05-07:00\",\"created_by\":{\"type\":\"user\",\"id\":\"175065494\",\"name\":\"Andrew Luck\",\"login\":\"aluck@colts.com\"},\"modified_by\":{\"type\":\"user\",\"id\":\"175065494\",\"name\":\"Andrew Luck\",\"login\":\"aluck@colts.com\"},\"owned_by\":{\"type\":\"user\",\"id\":\"175065494\",\"name\":\"Andrew Luck\",\"login\":\"aluck@colts.com\"},\"shared_link\":null,\"parent\":{\"type\":\"folder\",\"id\":\"0\",\"sequence_id\":null,\"etag\":null,\"name\":\"All Files\"},\"item_status\":\"active\", \"sort\":\"modified_at\", \"direction\":\"ASC\"}],\"offset\":0,\"limit\":1}";
+            IBoxRequest boxRequest = null;
+
+            Handler.Setup(h => h.ExecuteAsync<BoxCollection<BoxItem>>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxCollection<BoxItem>>>(new BoxResponse<BoxCollection<BoxItem>>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = responseString
+                }))
+                .Callback<IBoxRequest>(r => boxRequest = r);
+
+            /*** Act ***/
+            var startDate = new DateTime(1988, 11, 18, 9, 30, 0, DateTimeKind.Utc);
+            var endDate = new DateTime(2018, 11, 18, 9, 30, 0, DateTimeKind.Utc);
+            var results = await _searchManager.SearchAsync("test", createdAtRangeFromDate: startDate, updatedAtRangeToDate: endDate);
+
+            /*** Assert ***/
+            Assert.AreEqual("query=test&created_at_range=1988-11-18T09%3A30%3A00Z%2C&updated_at_range=%2C2018-11-18T09%3A30%3A00Z&limit=30&offset=0", boxRequest.GetQueryString());
         }
     }
 }

--- a/Box.V2/Config/Constants.cs
+++ b/Box.V2/Config/Constants.cs
@@ -187,7 +187,7 @@ namespace Box.V2.Config
 
         /*** Date Format ***/
         public const string RFC3339DateFormat = "yyyy-MM-ddTHH:mm:sszzz";
-        public const string RFC3339DateFormat_UTC = "yyyy-MM-dd'T'HH:mm:ss.fffK";
+        public const string RFC3339DateFormat_UTC = "yyyy-MM-dd'T'HH:mm:ssK";
 
         public static class RequestParameters
         {

--- a/Box.V2/Managers/BoxEventsManager.cs
+++ b/Box.V2/Managers/BoxEventsManager.cs
@@ -1,4 +1,4 @@
-﻿using Box.V2.Auth;
+using Box.V2.Auth;
 using Box.V2.Config;
 using Box.V2.Converter;
 using Box.V2.Models;
@@ -39,19 +39,8 @@ namespace Box.V2.Managers
                                                                         DateTime? createdAfter = null,
                                                                         DateTime? createdBefore = null)
         {
-            var createdAfterString = createdAfter.HasValue ? createdAfter.Value.ToUniversalTime().ToString("o") : null;
-            var createdBeforeString = createdBefore.HasValue ? createdBefore.Value.ToUniversalTime().ToString("o") : null;
-
-            // url encode 
-            if (!string.IsNullOrEmpty(createdAfterString))
-            {
-                createdAfterString = WebUtility.UrlEncode(createdAfterString);
-            }
-            
-            if (!string.IsNullOrEmpty(createdBeforeString))
-            {
-                createdBeforeString = WebUtility.UrlEncode(createdBeforeString);
-            }
+            var createdAfterString = createdAfter.HasValue ? createdAfter.Value.ToUniversalTime().ToString(Constants.RFC3339DateFormat_UTC) : null;
+            var createdBeforeString = createdBefore.HasValue ? createdBefore.Value.ToUniversalTime().ToString(Constants.RFC3339DateFormat_UTC) : null;
 
             BoxRequest request = new BoxRequest(_config.EventsUri)
                 .Param("stream_type", ENTERPRISE_EVENTS_STREAM_TYPE)

--- a/Box.V2/Managers/BoxFilesManager.cs
+++ b/Box.V2/Managers/BoxFilesManager.cs
@@ -278,7 +278,7 @@ namespace Box.V2.Managers
             }
             if (contentModifiedTime.HasValue)
             {
-                attributes.content_modified_at = contentModifiedTime.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss-00:00");
+                attributes.content_modified_at = contentModifiedTime.Value.ToUniversalTime().ToString(Constants.RFC3339DateFormat_UTC);
             }
 
             BoxMultiPartRequest request = new BoxMultiPartRequest(uploadUri) { Timeout = timeout }

--- a/Box.V2/Managers/BoxSearchManager.cs
+++ b/Box.V2/Managers/BoxSearchManager.cs
@@ -72,15 +72,11 @@ namespace Box.V2.Managers
             if (mdFilters != null)
             {               
                 mdFiltersString = _converter.Serialize(mdFilters);
-                mdFiltersString = WebUtility.UrlEncode(mdFiltersString);
             }
 
             var createdAtRangeString = BuildDateRangeField(createdAtRangeFromDate, createdAtRangeToDate);
             var updatedAtRangeString = BuildDateRangeField(updatedAtRangeFromDate, updatedAtRangeToDate);
             var sizeRangeString = BuildSizeRangeField(sizeRangeLowerBoundBytes, sizeRangeUpperBoundBytes);
-            createdAtRangeString = WebUtility.UrlEncode(createdAtRangeString);
-            updatedAtRangeString = WebUtility.UrlEncode(updatedAtRangeString);
-            sizeRangeString = WebUtility.UrlEncode(sizeRangeString);
 
             BoxRequest request = new BoxRequest(_config.SearchEndpointUri)
                 .Param("query", keyword)
@@ -108,8 +104,8 @@ namespace Box.V2.Managers
 
         private string BuildDateRangeField(DateTime? from, DateTime? to)
         {
-            var fromString = from.HasValue ? from.Value.ToString(Constants.RFC3339DateFormat) : String.Empty;
-            var toString = to.HasValue ? to.Value.ToString(Constants.RFC3339DateFormat) : String.Empty;
+            var fromString = from.HasValue ? from.Value.ToUniversalTime().ToString(Constants.RFC3339DateFormat_UTC) : String.Empty;
+            var toString = to.HasValue ? to.Value.ToUniversalTime().ToString(Constants.RFC3339DateFormat_UTC) : String.Empty;
 
             return BuildRangeString(fromString, toString);
         }


### PR DESCRIPTION
The previous fix to encode all query parameters caused some one-off places where query parameters were already being encoded to double-encode.  These one-off encodings have been removed, and tests added to ensure the encoding is correct.  Additionally the date format string constant has been updated to align with the format returned by the API, and places I found using bespoke date format strings have been updated to reference the constant instead.

Fixes #561 