### PR TITLE
Add ExternalAppUserId property to BoxUser model

### DIFF
--- a/Box.V2/Managers/BoxUsersManager.cs
+++ b/Box.V2/Managers/BoxUsersManager.cs
@@ -220,7 +220,7 @@ namespace Box.V2.Managers
         /// Retrieves information about a user in the enterprise. Requires enterprise administration authorization.
         /// </summary>
         /// <param name="userId">The user identifier.</param>
-        /// <returns>Returns the complete user object.</returns>
+        /// <returns>Returns the default representation of the user object.</returns>
         public async Task<BoxUser> GetUserInformationAsync(string userId)
         {
             BoxRequest request = new BoxRequest(_config.UserEndpointUri, userId);

--- a/Box.V2/Managers/BoxUsersManager.cs
+++ b/Box.V2/Managers/BoxUsersManager.cs
@@ -220,46 +220,10 @@ namespace Box.V2.Managers
         /// Retrieves information about a user in the enterprise. Requires enterprise administration authorization.
         /// </summary>
         /// <param name="userId">The user identifier.</param>
-        /// <param name="fields">Attribute(s) to include in the response.</param>
         /// <returns>Returns the complete user object.</returns>
-        public async Task<BoxUser> GetUserInformationAsync(string userId, IEnumerable<string> fields = null)
+        public async Task<BoxUser> GetUserInformationAsync(string userId)
         {
-            //This is supposed to retrieve the "complete" user object according to the API, so it should probably return all of the actual fields available by default.
-            if(fields == null)
-            {
-                fields = new List<string>()
-                {
-                    BoxUser.FieldAddress,
-                    BoxUser.FieldAvatarUrl,
-                    BoxUser.FieldCanSeeManagedUsers,
-                    BoxUser.FieldCreatedAt,
-                    BoxUser.FieldEnterprise,
-                    BoxUser.FieldExternalAppUserId, //This was previously missing from the default call 
-                    BoxUser.FieldHostname,
-                    BoxUser.FieldIsExemptFromDeviceLimits,
-                    BoxUser.FieldIsExemptFromLoginVerification,
-                    BoxUser.FieldIsExternalCollabRestricted,
-                    BoxUser.FieldIsSyncEnabled,
-                    BoxUser.FieldIsPlatformAccessOnly,
-                    BoxUser.FieldJobTitle,
-                    BoxUser.FieldLanguage,
-                    BoxUser.FieldLogin,
-                    BoxUser.FieldMaxUploadSize,
-                    BoxUser.FieldModifiedAt,
-                    BoxUser.FieldMyTags,
-                    BoxUser.FieldName,
-                    BoxUser.FieldPhone,
-                    BoxUser.FieldRole,
-                    BoxUser.FieldSpaceAmount,
-                    BoxUser.FieldSpaceUsed,
-                    BoxUser.FieldStatus,
-                    BoxUser.FieldTimezone,
-                    BoxUser.FieldTrackingCodes
-                };
-            }
-
-            BoxRequest request = new BoxRequest(_config.UserEndpointUri, userId)
-                .Param(ParamFields, fields);
+            BoxRequest request = new BoxRequest(_config.UserEndpointUri, userId);
 
             IBoxResponse<BoxUser> response = await ToResponseAsync<BoxUser>(request).ConfigureAwait(false);
 

--- a/Box.V2/Managers/BoxUsersManager.cs
+++ b/Box.V2/Managers/BoxUsersManager.cs
@@ -220,10 +220,46 @@ namespace Box.V2.Managers
         /// Retrieves information about a user in the enterprise. Requires enterprise administration authorization.
         /// </summary>
         /// <param name="userId">The user identifier.</param>
+        /// <param name="fields">Attribute(s) to include in the response.</param>
         /// <returns>Returns the complete user object.</returns>
-        public async Task<BoxUser> GetUserInformationAsync(string userId)
+        public async Task<BoxUser> GetUserInformationAsync(string userId, IEnumerable<string> fields = null)
         {
-            BoxRequest request = new BoxRequest(_config.UserEndpointUri, userId);
+            //This is supposed to retrieve the "complete" user object according to the API, so it should probably return all of the actual fields available by default.
+            if(fields == null)
+            {
+                fields = new List<string>()
+                {
+                    BoxUser.FieldAddress,
+                    BoxUser.FieldAvatarUrl,
+                    BoxUser.FieldCanSeeManagedUsers,
+                    BoxUser.FieldCreatedAt,
+                    BoxUser.FieldEnterprise,
+                    BoxUser.FieldExternalAppUserId, //This was previously missing from the default call 
+                    BoxUser.FieldHostname,
+                    BoxUser.FieldIsExemptFromDeviceLimits,
+                    BoxUser.FieldIsExemptFromLoginVerification,
+                    BoxUser.FieldIsExternalCollabRestricted,
+                    BoxUser.FieldIsSyncEnabled,
+                    BoxUser.FieldIsPlatformAccessOnly,
+                    BoxUser.FieldJobTitle,
+                    BoxUser.FieldLanguage,
+                    BoxUser.FieldLogin,
+                    BoxUser.FieldMaxUploadSize,
+                    BoxUser.FieldModifiedAt,
+                    BoxUser.FieldMyTags,
+                    BoxUser.FieldName,
+                    BoxUser.FieldPhone,
+                    BoxUser.FieldRole,
+                    BoxUser.FieldSpaceAmount,
+                    BoxUser.FieldSpaceUsed,
+                    BoxUser.FieldStatus,
+                    BoxUser.FieldTimezone,
+                    BoxUser.FieldTrackingCodes
+                };
+            }
+
+            BoxRequest request = new BoxRequest(_config.UserEndpointUri, userId)
+                .Param(ParamFields, fields);
 
             IBoxResponse<BoxUser> response = await ToResponseAsync<BoxUser>(request).ConfigureAwait(false);
 

--- a/Box.V2/Models/BoxUser.cs
+++ b/Box.V2/Models/BoxUser.cs
@@ -34,6 +34,7 @@ namespace Box.V2.Models
         public const string FieldIsExternalCollabRestricted = "is_external_collab_restricted";
         public const string FieldMyTags = "my_tags";
         public const string FieldHostname = "hostname";
+        public const string FieldExternalAppUserId = "external_app_user_id";
 
         /// <summary>
         /// The name of this user
@@ -184,5 +185,12 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = FieldHostname)]
         public string Hostname { get; private set; }
+
+        /// <summary>
+        /// The external app user id that has been set for the app user.  An arbitrary identifier that can be used by external user sync tools to link this Box User to an external user.
+        /// Example values of this field could be an Active Directory Object ID or primary key from a user-tracking database. We recommend use of this field in order to avoid issues when email addresses and names are updated in either Box or external systems.
+        /// </summary>
+        [JsonProperty(PropertyName = FieldExternalAppUserId)]
+        public string ExternalAppUserId { get; private set; }
     }
 }


### PR DESCRIPTION
- already part of the BoxUserRequest object, and now it should be possible to pull this back in a user object if it is possible to set it in a request for creation or update.


