### PR TITLE
Add constructor for BoxTrackingCode 

### DIFF
--- a/Box.V2/Models/BoxTrackingCode.cs
+++ b/Box.V2/Models/BoxTrackingCode.cs
@@ -13,6 +13,19 @@ namespace Box.V2.Models
         public const string FieldValue = "value";
 
         /// <summary>
+        /// Constructor for creating new BoxTrackingCodes with a given name and value, such that they can be created and passed in BoxUserRequests
+        /// </summary>
+        /// <param name="name">Name of a tracking code registered by the enterprise administrator.</param>
+        /// <param name="value">Value of the tracking code.</param>
+        public BoxTrackingCode(string name, string value)
+        {
+            //Per description below, this should always be tracking_code
+            Type = "tracking_code";
+            Name = name;
+            Value = value;
+        }
+
+        /// <summary>
         /// The type of the tracking code, should be tracking_code
         /// </summary>
         [JsonProperty(PropertyName = FieldType)]


### PR DESCRIPTION
This is intended to allow creation of codes for use in BoxUserRequests, but still leave BoxUser.TrackingCodes immutable.

Closes #593