### PR TITLE
Fixed metadata query

### DIFF
--- a/Box.V2.Test.Integration/BoxMetadataManagerTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxMetadataManagerTestIntegration.cs
@@ -191,7 +191,7 @@ namespace Box.V2.Test.Integration
                 {
                     { metadataTemplateField, metadataTemplateFieldValue }
                 };
-                Dictionary<string, object> metadata = await _client.MetadataManager.SetFolderMetadataAsync(folderId: folder.Id, metadataValues, template.Scope, template.TemplateKey);
+                Dictionary<string, object> metadata = await _client.MetadataManager.SetFolderMetadataAsync(folder.Id, metadataValues, template.Scope, template.TemplateKey);
             }
             catch { }
 

--- a/Box.V2.Test.Integration/BoxResourceManagerTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxResourceManagerTestIntegration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Box.V2.Auth;

--- a/Box.V2.Test.Integration/BoxResourceManagerTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxResourceManagerTestIntegration.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Box.V2.Auth;

--- a/Box.V2.Test/BoxMetadataManagerTest.cs
+++ b/Box.V2.Test/BoxMetadataManagerTest.cs
@@ -600,8 +600,7 @@ namespace Box.V2.Test
             JObject payload = JObject.Parse(boxRequest.Payload);
             Assert.AreEqual("enterprise_123456.someTemplate", payload["from"]);
             Assert.AreEqual("amount >= :arg", payload["query"]);
-            JObject payloadQueryParam = JObject.Parse(payload["query_params"].ToString());
-            Assert.AreEqual(100, payloadQueryParam["arg"]);
+            Assert.AreEqual(100, payload["query_params"]["arg"]);
             Assert.AreEqual("5555", payload["ancestor_folder_id"]);
             Assert.AreEqual("amountAsc", payload["use_index"]);
             JArray payloadOrderBy = JArray.Parse(payload["order_by"].ToString());

--- a/Box.V2/Managers/BoxMetadataManager.cs
+++ b/Box.V2/Managers/BoxMetadataManager.cs
@@ -346,7 +346,7 @@ namespace Box.V2.Managers
 
             if (queryParameters != null)
             {
-                queryObject.query_params = _converter.Serialize(queryParameters);
+                queryObject.query_params = JObject.FromObject(queryParameters);
             }
 
             if (indexName != null)
@@ -364,7 +364,7 @@ namespace Box.V2.Managers
                     orderByObject.direction = order.Direction.ToString();
                     orderByList.Add(orderByObject);
                 }
-                queryObject.order_by = _converter.Serialize(orderByList); ;
+                queryObject.order_by = JArray.FromObject(orderByList);
             }
 
             if (marker != null)
@@ -372,15 +372,16 @@ namespace Box.V2.Managers
                 queryObject.marker = marker;
             }
 
-            string queryStr = queryObject.ToString();
+            string queryStr = _converter.Serialize(queryObject);
 
             BoxRequest request = new BoxRequest(_config.MetadataQueryUri)
                 .Method(RequestMethod.Post)
                 .Payload(queryStr);
+            request.ContentType = Constants.RequestParameters.ContentTypeJson;
 
             if (autoPaginate)
             {
-                return await AutoPaginateMarkerMetadataQuery<BoxMetadataQueryItem>(request, limit);
+                return await AutoPaginateMarkerMetadataQuery<BoxMetadataQueryItem>(request);
             }
             else
             {

--- a/Box.V2/Managers/BoxResourceManager.cs
+++ b/Box.V2/Managers/BoxResourceManager.cs
@@ -232,9 +232,8 @@ namespace Box.V2.Managers
         /// </summary>
         /// <typeparam name="T">The type of BoxCollectionMarkerBased item to expect.</typeparam>
         /// <param name="request">The pre-configured BoxRequest object.</param>
-        /// <param name="limit">The limit specific to the endpoint.</param>
         /// <returns></returns>
-        protected async Task<BoxCollectionMarkerBased<T>> AutoPaginateMarkerMetadataQuery<T>(BoxRequest request, int limit) where T : BoxMetadataQueryItem, new()
+        protected async Task<BoxCollectionMarkerBased<T>> AutoPaginateMarkerMetadataQuery<T>(BoxRequest request) where T : BoxMetadataQueryItem, new()
         {
             var allItemsCollection = new BoxCollectionMarkerBased<T>();
             allItemsCollection.Entries = new List<T>();


### PR DESCRIPTION
The `Metadata.ExecuteMetadataQueryAsync()` method was not correctly serializing the POST body when `queryParameters` or `orderBy` parameters were passed. Also, the method was not adding the JSON content type header. Both were fixed.