### PR TITLE
Fix deadlock issue for JWT Auth in UI elements

### DIFF
--- a/Box.V2/Request/HttpRequestHandler.cs
+++ b/Box.V2/Request/HttpRequestHandler.cs
@@ -38,8 +38,8 @@ namespace Box.V2.Request
 
                 HttpRequestMessage httpRequest = getHttpRequest(request, isMultiPartRequest, isBinaryRequest);
                 Debug.WriteLine(string.Format("RequestUri: {0}", httpRequest.RequestUri));
-                HttpResponseMessage response = await getResponse(request, isStream, httpRequest);
-                BoxResponse<T> boxResponse = await getBoxResponse<T>(isStream, response);
+                HttpResponseMessage response = await getResponse(request, isStream, httpRequest).ConfigureAwait(false);
+                BoxResponse<T> boxResponse = await getBoxResponse<T>(isStream, response).ConfigureAwait(false);
 
                 return boxResponse;
             }
@@ -68,7 +68,7 @@ namespace Box.V2.Request
                 {
                     HttpRequestMessage httpRequest = getHttpRequest(request, isMultiPartRequest, isBinaryRequest);
                     Debug.WriteLine(string.Format("RequestUri: {0}", httpRequest.RequestUri));
-                    HttpResponseMessage response = await getResponse(request, isStream, httpRequest);
+                    HttpResponseMessage response = await getResponse(request, isStream, httpRequest).ConfigureAwait(false);
 
                     //need to wait for Retry-After seconds and then retry request
                     var retryAfterHeader = response.Headers.RetryAfter;
@@ -98,7 +98,7 @@ namespace Box.V2.Request
                     }
                     else
                     {
-                        BoxResponse<T> boxResponse = await getBoxResponse<T>(isStream, response);
+                        BoxResponse<T> boxResponse = await getBoxResponse<T>(isStream, response).ConfigureAwait(false);
 
                         return boxResponse;
                     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next Release
 - Add ability to get and set a notification email address for a user
+- Fix deadlock issue for JWT authentication in UI elements
 
 ## 3.22.0 [2020-02-25]
 - Fixed Authentication Request Retries


### PR DESCRIPTION
When a user calls `BoxJWT.AdminToken()` to get a token in a UI element, a deadlock issue will occur because the underlying async request methods in `HttpRequestHandler.cs` don't have `Configure.await(false)` appended to them. This PR is in regards to this issue (#638).

Why this is a fix is detailed in this [article](https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f).