### PR TITLE
Fix Box notification email field

### DIFF
--- a/Box.V2.Test/BoxUsersManagerTest.cs
+++ b/Box.V2.Test/BoxUsersManagerTest.cs
@@ -293,7 +293,7 @@ namespace Box.V2.Test
            .Returns(() => Task.FromResult<IBoxResponse<BoxCollectionMarkerBased<BoxUser>>>(new BoxResponse<BoxCollectionMarkerBased<BoxUser>>()
            {
                Status = ResponseStatus.Success,
-               ContentString = "{\"entries\":[{\"type\":\"user\",\"id\":\"1234567890\",\"name\":\"Joey Burns\",\"login\":\"jburns@example.com\",\"created_at\":\"2020-01-01T01:01:01-07:00\",\"modified_at\":\"2020-01-01T01:01:01-08:00\",\"language\":\"en\",\"timezone\":\"America/Los_Angeles\",\"space_amount\":10737418240,\"space_used\":0,\"max_upload_size\":5368709120,\"status\":\"active\",\"job_title\":\"\",\"phone\":\"\",\"address\":\"\",\"avatar_url\":\"https://example.app.box.com/api/avatar/large/1234567890\",\"notification_email\":[]}],\"limit\":1,\"next_marker\":\"zxcvbnmasdfghjklqwertyuiop1234567890QWERTYUIOPASDFGHJKLZXCVBNM\"}"
+               ContentString = "{\"entries\":[{\"type\":\"user\",\"id\":\"1234567890\",\"name\":\"Joey Burns\",\"login\":\"jburns@example.com\",\"created_at\":\"2020-01-01T01:01:01-07:00\",\"modified_at\":\"2020-01-01T01:01:01-08:00\",\"language\":\"en\",\"timezone\":\"America/Los_Angeles\",\"space_amount\":10737418240,\"space_used\":0,\"max_upload_size\":5368709120,\"status\":\"active\",\"job_title\":\"\",\"phone\":\"\",\"address\":\"\",\"avatar_url\":\"https://example.app.box.com/api/avatar/large/1234567890\",\"notification_email\":{}}],\"limit\":1,\"next_marker\":\"zxcvbnmasdfghjklqwertyuiop1234567890QWERTYUIOPASDFGHJKLZXCVBNM\"}"
            }));
 
             String marker = "qwertyuiopASDFGHJKLzxcvbnm1234567890QWERTYUIOPasdfghjklZXCVBNM";

--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -100,6 +100,8 @@
     <Compile Include="Models\BoxGroupFolderCollaborationEventSource.cs" />
     <Compile Include="Models\BoxMetadataFieldFilter.cs" />
     <Compile Include="Models\BoxMetadataQueryItem.cs" />
+    <Compile Include="Models\BoxNotificationEmail.cs" />
+    <Compile Include="Models\BoxNotificationEmailField.cs" />
     <Compile Include="Models\BoxRepresentation.cs" />
     <Compile Include="Models\BoxRepresentationContent.cs" />
     <Compile Include="Models\BoxRepresentationInfo.cs" />


### PR DESCRIPTION
`BoxNotificationEmail` and `BoxNotificationEmailField` were not added to the `.csproj` file, so they were not accessible in the SDK. This PR fixes this issue by adding them to the `.csproj` file.