### PR TITLE
Add path parameter sanitization

### DIFF
--- a/Box.V2.Test/BoxRequestTest.cs
+++ b/Box.V2.Test/BoxRequestTest.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Box.V2.Utility;
+using Box.V2.Exceptions;
 
 namespace Box.V2.Test
 {
@@ -17,6 +18,25 @@ namespace Box.V2.Test
             Assert.AreEqual(request.Method, RequestMethod.Get);
             Assert.AreEqual(baseUri, request.Host);
             Assert.IsNotNull(request.Parameters);
+        }
+
+        [TestMethod]
+        public void InvalidParameters_InvalidRequest()
+        {
+            Uri baseUri = new Uri("http://api.box.com/v2");
+            try
+            {
+                IBoxRequest request = new BoxRequest(baseUri, "auth/../oauth2/../");
+                Assert.Fail(); // raises AssertionException
+            }
+            catch (BoxException) {}
+
+            try
+            {
+                IBoxRequest request = new BoxRequest(baseUri, "auth/../../oauth2/../");
+                Assert.Fail(); // raises AssertionException
+            }
+            catch (BoxException) {}
         }
 
         [TestMethod]

--- a/Box.V2/Wrappers/BoxRequest.cs
+++ b/Box.V2/Wrappers/BoxRequest.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Net;
+using System.Text.RegularExpressions;
+using Box.V2.Exceptions;
 
 namespace Box.V2
 {
@@ -21,9 +23,14 @@ namespace Box.V2
         /// <param name="path"></param>
         public BoxRequest(Uri hostUri, string path)
         {
+            string pattern = @"\/\.+";
+            if (Regex.IsMatch(path, pattern) == true)
+            {
+                throw new BoxException($"An invalid path parameter exists in {path}. Relative path parameters cannot be passed.");
+            }
+
             Host = hostUri;
             Path = path;
-
             HttpHeaders = new Dictionary<string, string>();
             Parameters = new Dictionary<string, string>();
             PayloadParameters = new Dictionary<string, string>();
@@ -75,7 +82,7 @@ namespace Box.V2
                 {
                     newQuery = Parameters.Count == 0 ? existingQuery : string.Format("{0}&{1}", existingQuery, GetQueryString());
                 }
-
+            
                 return new Uri(Uri, newQuery);
             }
         }

--- a/Box.V2/Wrappers/BoxRequest.cs
+++ b/Box.V2/Wrappers/BoxRequest.cs
@@ -24,7 +24,7 @@ namespace Box.V2
         public BoxRequest(Uri hostUri, string path)
         {
             string pattern = @"\/\.+";
-            if (Regex.IsMatch(path, pattern) == true)
+            if (path != null && Regex.IsMatch(path, pattern) == true)
             {
                 throw new BoxException($"An invalid path parameter exists in {path}. Relative path parameters cannot be passed.");
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Next Release
+- Add path parameter sanitization
+
 ## 3.23.0 [2020-05-12]
 - Add ability to get and set a notification email address for a user
 - Fix deadlock issue for JWT authentication in UI elements


### PR DESCRIPTION
Sanitizes path parameters when constructing a URI. If the path contains relative paths such as `/../`, an error will be thrown.