### PR TITLE
Change API version used for creating upload sessions for new file versions

### DIFF
--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -88,6 +88,7 @@
     <Compile Include="Managers\BoxWebLinksManager.cs" />
     <Compile Include="Models\BoxApplication.cs" />
     <Compile Include="Models\BoxAssignmentCounts.cs" />
+    <Compile Include="Models\BoxClassification.cs" />
     <Compile Include="Models\BoxCollectionItem.cs" />
     <Compile Include="Models\BoxDevicePin.cs" />
     <Compile Include="Models\BoxEmailAlias.cs" />

--- a/Box.V2/Config/BoxConfig.cs
+++ b/Box.V2/Config/BoxConfig.cs
@@ -158,10 +158,7 @@ namespace Box.V2.Config
         /// Upload session
         /// </summary>
         public virtual Uri FilesUploadSessionEndpointUri { get { return new Uri(BoxUploadApiUri, Constants.FilesUploadSessionString); } }
-
-        //public virtual Uri FilesNewVersionEndpointUri { get { return new Uri(BoxUploadApiUri, Constants.FilesNewVersionString); } }
         public virtual Uri FilesPreflightCheckUri { get { return new Uri(BoxApiUri, Constants.FilesUploadString); } }
-        //public virtual Uri FilesPreflightCheckNewVersionUri { get { return new Uri(BoxApiUri, Constants.FilesNewVersionString); } }
         public virtual Uri CommentsEndpointUri { get { return new Uri(BoxApiUri, Constants.CommentsString); } }
         public virtual Uri SearchEndpointUri { get { return new Uri(BoxApiUri, Constants.SearchString); } }
         public virtual Uri UserEndpointUri { get { return new Uri(BoxApiUri, Constants.UserString); } }

--- a/Box.V2/Config/BoxConfig.cs
+++ b/Box.V2/Config/BoxConfig.cs
@@ -126,7 +126,6 @@ namespace Box.V2.Config
         public virtual Uri BoxAccountApiHostUri { get; set; } = new Uri(Constants.BoxAccountApiHostUriString);
         public virtual Uri BoxApiUri { get; set; } = new Uri(Constants.BoxApiUriString);
         public virtual Uri BoxUploadApiUri { get; set; } = new Uri(Constants.BoxUploadApiUriString);
-        public virtual Uri BoxUploadApiUriV21 { get; set; } = new Uri(Constants.BoxUploadApiUriV21String);
 
         public virtual string ClientId { get; private set; }
         public virtual string ConsumerKey { get; private set; }

--- a/Box.V2/Config/Constants.cs
+++ b/Box.V2/Config/Constants.cs
@@ -12,7 +12,6 @@ namespace Box.V2.Config
         public const string BoxAccountApiHostUriString = "https://account.box.com/api/";
         public const string BoxApiUriString = "https://api.box.com/2.0/";
         public const string BoxUploadApiUriString = "https://upload.box.com/api/2.0/";
-        public const string BoxUploadApiUriV21String = "https://upload.box.com/api/2.1/";
 
 
         /*** API Endpoints ***/
@@ -90,7 +89,7 @@ namespace Box.V2.Config
         public const string FilesEndpointString = BoxApiUriString + FilesString;
         public const string FilesUploadEndpointString = BoxUploadApiUriString + FilesUploadString;
         public const string FilesNewVersionEndpointString = BoxUploadApiUriString + FilesNewVersionString;
-        public const string FilesNewVersionUploadSessionEndpointString = BoxUploadApiUriV21String + FilesNewVersionUploadSessionString;
+        public const string FilesNewVersionUploadSessionEndpointString = BoxUploadApiUriString + FilesNewVersionUploadSessionString;
         public const string FilesPreflightCheckNewVersionString = BoxApiUriString + FilesNewVersionString;
         public const string CommentsEndpointString = BoxApiUriString + CommentsString;
         public const string SearchEndpointString = BoxApiUriString + SearchString;


### PR DESCRIPTION
The endpoint for creating upload sessions for new file versions was using version 2.1 of the API. Every other endpoint used version 2.0 of the API. This PR changed the endpoint from 2.1 to 2.0. The admin experience team said both versions of the API call the same PHP code in the monolith and are not different in any way. A similar change was made for the upload session endpoint for new files in PR #287.