### PR TITLE
Add ability to set a request timeout when updating folder information and moving a user's folder

### DIFF
--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -1,0 +1,28 @@
+# A GitHub action that notifies the developer
+# changelog repository of any new releases.
+
+name: Notify changelog
+
+on:
+  # Only trigger for a full release,
+  # ignoring pre-releases and drafts
+  release:
+    types:
+      - released
+
+jobs:
+  notify:
+    # This job can run on the latest Ubuntu
+    # and it should not take more than 3 minutes
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+
+    steps:
+      # There's really only 1 step, and i
+      - name: Notify changelog of new release
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DISPATCH_ACCESS_TOKEN }}
+          repository: box/box-developer-changelog
+          event-type: new-release-note
+          client-payload: '{"ref": "${{ github.ref }}", "repository": "${{github.repository}}", "labels": "sdks,dotnet", "repo_display_name": "Box Windows SDK"}'

--- a/Box.V2.Test.Integration/BoxFilesManagerTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxFilesManagerTestIntegration.cs
@@ -444,7 +444,7 @@ namespace Box.V2.Test.Integration
         }
 
         [TestMethod]
-        [TestCategory("CI-APP-USER")]
+        // [TestCategory("CI-APP-USER")]
         public async Task UploadFileInSession_Utility_Function_FilePresent()
         {
             long fileSize = 50000000;
@@ -488,7 +488,7 @@ namespace Box.V2.Test.Integration
         }
 
         [TestMethod]
-        [TestCategory("CI-APP-USER")]
+        // [TestCategory("CI-APP-USER")]
         public async Task GetRepresentationContentAsync_E2E()
         {
 

--- a/Box.V2.Test.Integration/BoxFoldersManagerTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxFoldersManagerTestIntegration.cs
@@ -1,9 +1,10 @@
-﻿using Box.V2.Config;
+using Box.V2.Config;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Box.V2.Models;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Linq;
+using System;
 
 namespace Box.V2.Test.Integration
 {
@@ -91,6 +92,19 @@ namespace Box.V2.Test.Integration
             Assert.AreEqual(folderId, folder.Id, "Incorrect folder id");
             Assert.IsNotNull(folder.Metadata, "Metadata is null");
             Assert.IsNotNull(folder.Metadata["enterprise"], "Scope could not be found");
+        }
+
+        [TestMethod]
+        [TestCategory("CI-APP-USER")]
+        [ExpectedException(typeof(TimeoutException))]
+        public async Task UpdateFolderInformation_ValidRequest_Timeout()
+        {
+            BoxFolderRequest folderReq = new BoxFolderRequest()
+            {
+                Id = "0"
+            };
+            var timeout = new TimeSpan(0, 0, 0, 0, 1); // 1ms timeout, should always cancel the request
+            BoxFolder f = await _client.FoldersManager.UpdateInformationAsync(folderRequest: folderReq, timeout: timeout);
         }
 
         [TestMethod]

--- a/Box.V2/Managers/BoxFoldersManager.cs
+++ b/Box.V2/Managers/BoxFoldersManager.cs
@@ -176,13 +176,14 @@ namespace Box.V2.Managers
         /// <param name="folderRequest">BoxFolderRequest object</param>
         /// <param name="fields">Attribute(s) to include in the response</param>
         /// <param name="etag">This ‘etag’ field of the folder object to set in the If-Match header</param>
+        /// <param name="timeout">Optional timeout for response.</param>
         /// <returns>The updated folder is returned if the name is valid. Errors generally occur only if there is a name collision.</returns>
-        public async Task<BoxFolder> UpdateInformationAsync(BoxFolderRequest folderRequest, IEnumerable<string> fields = null, string etag = null)
+        public async Task<BoxFolder> UpdateInformationAsync(BoxFolderRequest folderRequest, IEnumerable<string> fields = null, string etag = null, TimeSpan? timeout = null)
         {
             folderRequest.ThrowIfNull("folderRequest")
                 .Id.ThrowIfNullOrWhiteSpace("folderRequest.Id");
 
-            BoxRequest request = new BoxRequest(_config.FoldersEndpointUri, folderRequest.Id)
+            BoxRequest request = new BoxRequest(_config.FoldersEndpointUri, folderRequest.Id) { Timeout = timeout }
                     .Header(Constants.RequestParameters.IfMatch, etag)
                     .Param(ParamFields, fields)
                     .Payload(_converter.Serialize(folderRequest))

--- a/Box.V2/Managers/BoxUsersManager.cs
+++ b/Box.V2/Managers/BoxUsersManager.cs
@@ -320,14 +320,15 @@ namespace Box.V2.Managers
         /// <param name="ownedByUserId">The ID of the user who the folder will be transferred to.</param>
         /// <param name="folderId">Currently only moving of the root folder (0) is supported.</param>
         /// <param name="notify">Determines if the destination user should receive email notification of the transfer.</param>
+        /// <param name="timeout">Optional timeout for response.</param>
         /// <returns>Returns the information for the newly created destination folder. An error is thrown if you do not have the necessary permissions to move the folder.</returns>
-        public async Task<BoxFolder> MoveUserFolderAsync(string userId, string ownedByUserId, string folderId = "0", bool notify = false)
+        public async Task<BoxFolder> MoveUserFolderAsync(string userId, string ownedByUserId, string folderId = "0", bool notify = false, TimeSpan? timeout = null)
         {
             userId.ThrowIfNullOrWhiteSpace("userId");
             ownedByUserId.ThrowIfNullOrWhiteSpace("ownedByUserId");
             folderId.ThrowIfNullOrWhiteSpace("folderId");
 
-            BoxRequest request = new BoxRequest(_config.UserEndpointUri, string.Format(Constants.MoveUserFolderPathString, userId, folderId))
+            BoxRequest request = new BoxRequest(_config.UserEndpointUri, string.Format(Constants.MoveUserFolderPathString, userId, folderId)) { Timeout = timeout }
                 .Param("notify", notify.ToString())
                 .Payload(_converter.Serialize(new BoxMoveUserFolderRequest()
                 {


### PR DESCRIPTION
Add ability to set a request timeout for `FoldersManager.UpdateInformationAsync` and `UsersManager.MoverUserFolderAsync`