### PR TITLE
Fix auth retry for expired claim

### DIFF
--- a/Box.V2/JWTAuth/BoxJWTAuth.cs
+++ b/Box.V2/JWTAuth/BoxJWTAuth.cs
@@ -171,20 +171,35 @@ namespace Box.V2.JWTAuth
                     // because the stream cannot be reset) and we haven't exceeded the number of allowed retries, then retry the request.
                     // If we get a 202 code and has a retry-after header, we will retry after.
                     // If we get a 400 due to exp claim issue, this can happen if the current system time is too different from the Box server time, so retry.
-                    if ((ex.StatusCode == HttpRequestHandler.TooManyRequests
-                        ||
-                        ex.StatusCode == HttpStatusCode.InternalServerError
-                        ||
-                        ex.StatusCode == HttpStatusCode.BadGateway
-                        ||
-                        ex.StatusCode == HttpStatusCode.ServiceUnavailable
-                        ||
-                        ex.StatusCode == HttpStatusCode.GatewayTimeout
-                        ||
-                        (ex.StatusCode == HttpStatusCode.Accepted && retryAfterHeader != null)
-                        ||
-                        (ex.StatusCode == HttpStatusCode.BadRequest && ex.Error.Code.Contains("invalid_grant") && ex.Error.Description.Contains("exp")))
-                        && retryCounter++ < HttpRequestHandler.RetryLimit)
+                    if ((ex.StatusCode != null
+                            &&
+                            (ex.StatusCode == HttpRequestHandler.TooManyRequests
+                            ||
+                            ex.StatusCode == HttpStatusCode.InternalServerError
+                            ||
+                            ex.StatusCode == HttpStatusCode.BadGateway
+                            ||
+                            ex.StatusCode == HttpStatusCode.ServiceUnavailable
+                            ||
+                            ex.StatusCode == HttpStatusCode.GatewayTimeout
+                            ||
+                            (ex.StatusCode == HttpStatusCode.Accepted 
+                                && 
+                                retryAfterHeader != null)
+                            ||
+                            (ex.StatusCode == HttpStatusCode.BadRequest 
+                                && 
+                                ex.Error != null 
+                                && 
+                                ex.Error.Code != null 
+                                && 
+                                ex.Error.Code.Contains("invalid_grant") 
+                                && 
+                                ex.Error.Description != null 
+                                && 
+                                ex.Error.Description.Contains("exp"))))
+                        && 
+                        retryCounter++ < HttpRequestHandler.RetryLimit)
                     {
 
                         TimeSpan delay = expBackoff.GetRetryTimeout(retryCounter);


### PR DESCRIPTION
Fixes a bug discovered in #645 and #693 where we were not properly reading the error code and description from the exception thrown for an expired claim ("clock skew").
This bug was preventing any requests to be retried and from returning the actual expired claim exception to the client.
Now that retries should occur properly when there is "clock skew" between the client and server, the JWT assertion should be created using the Box server time found in the response headers, which should result in a successful authentication on the first retry.