### PR TITLE
Add BoxConfigBuilder and make BoxConfig immutable

### DIFF
--- a/Box.V2.Samples.Core.AppUser.Create/Program.cs
+++ b/Box.V2.Samples.Core.AppUser.Create/Program.cs
@@ -1,4 +1,4 @@
-﻿using Box.V2.Config;
+using Box.V2.Config;
 using Box.V2.JWTAuth;
 using Box.V2.Models;
 using System;
@@ -86,7 +86,7 @@ namespace Box.V2.Samples.Core.AppUser.Create
             IBoxConfig config = null;
             using (FileStream fs = new FileStream(@"YOUR_JSON_FILE_HERE", FileMode.Open))
             {
-                config = BoxConfig.CreateFromJsonFile(fs);
+                config = BoxConfigBuilder.CreateFromJsonFile(fs).Build();
             }
 
             return config;

--- a/Box.V2.Samples.Core.File.Upload/Program.cs
+++ b/Box.V2.Samples.Core.File.Upload/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using Box.V2.Config;
@@ -41,7 +41,8 @@ namespace Box.V2.Core.Sample
 
             var auth = new OAuthSession(accessToken, "YOUR_REFRESH_TOKEN", 3600, "bearer");
 
-            var config = new BoxConfig("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET", new Uri("http://boxsdk"));
+            var config = new BoxConfigBuilder("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET", new Uri("http://boxsdk"))
+                .Build();
             var client = new BoxClient(config, auth);
 
             var file = File.OpenRead(localFilePath);

--- a/Box.V2.Samples.Core.HttpProxy/Program.cs
+++ b/Box.V2.Samples.Core.HttpProxy/Program.cs
@@ -10,10 +10,10 @@ namespace Box.V2.Samples.Core.HttpProxy
     {
         static void Main(string[] args)
         {
-            var boxConfig = BoxConfig.CreateFromJsonString(GetConfigJson());
-
-            // Set web proxy
-            boxConfig.WebProxy = new BoxHttpProxy();
+            var boxConfig = BoxConfigBuilder.CreateFromJsonString(GetConfigJson())
+                // Set web proxy
+                .SetWebProxy(new BoxHttpProxy())
+                .Build();
 
             var boxJWT = new BoxJWTAuth(boxConfig);
 

--- a/Box.V2.Samples.JWTAuth/Program.cs
+++ b/Box.V2.Samples.JWTAuth/Program.cs
@@ -33,7 +33,8 @@ namespace Box.V2.Samples.JWTAuth
             // rename the private_key.pem.example to private_key.pem and put your JWT private key in the file
             var privateKey = File.ReadAllText("private_key.pem.example");
 
-            var boxConfig = new BoxConfig(CLIENT_ID, CLIENT_SECRET, ENTERPRISE_ID, privateKey, JWT_PRIVATE_KEY_PASSWORD, JWT_PUBLIC_KEY_ID);
+            var boxConfig = new BoxConfigBuilder(CLIENT_ID, CLIENT_SECRET, ENTERPRISE_ID, privateKey, JWT_PRIVATE_KEY_PASSWORD, JWT_PUBLIC_KEY_ID)
+                .Build();
             var boxJWT = new BoxJWTAuth(boxConfig);
 
             var adminToken = boxJWT.AdminToken();

--- a/Box.V2.Samples.TransactionalAuth/Program.cs
+++ b/Box.V2.Samples.TransactionalAuth/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Box.V2.Auth;
 using Box.V2.Auth.Token;
@@ -39,7 +39,8 @@ namespace Box.V2.Samples.TransactionalAuth
         {
             var auth = new OAuthSession(token, "YOUR_REFRESH_TOKEN", 3600, "bearer");
 
-            var config = new BoxConfig(string.Empty, string.Empty, new Uri("http://boxsdk"));
+            var config = new BoxConfigBuilder(string.Empty, string.Empty, new Uri("http://boxsdk"))
+                .Build();
             var client = new BoxClient(config, auth);
 
             return client;

--- a/Box.V2.Test.Integration/BoxAuthTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxAuthTestIntegration.cs
@@ -22,7 +22,8 @@ namespace Box.V2.Test.Integration
         [TestMethod]
         public void retriesWithNewJWTAssertionOnErrorResponseAndSucceeds()
         {
-            var config = new BoxConfig(ClientId, ClientSecret, EnterpriseId, privateKey, passphrase, publicKeyID);
+            var config = new BoxConfigBuilder(ClientId, ClientSecret, EnterpriseId, privateKey, passphrase, publicKeyID)
+                .Build();
             var session = new BoxJWTAuth(config);
             var adminToken = session.AdminToken();
             adminClient = session.AdminClient(adminToken);

--- a/Box.V2.Test.Integration/BoxConfigTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxConfigTestIntegration.cs
@@ -1,4 +1,4 @@
-﻿using Box.V2.Config;
+using Box.V2.Config;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using System.Threading.Tasks;
 
@@ -24,11 +24,15 @@ namespace Box.V2.Test.Integration
               'webhooks': {},
               'enterpriseID': 'eid-123'
             }";
-            var config = BoxConfig.CreateFromJsonString(jsonString);
+            var config = BoxConfigBuilder
+                .CreateFromJsonString(jsonString)
+                .Build();
             Assert.AreEqual(config.BoxApiUri, new System.Uri(Constants.BoxApiUriString));
 
             System.Uri exampleUri = new System.Uri("https://example.com/");
-            config.BoxApiUri = exampleUri;
+            config = BoxConfigBuilder.CreateFromJsonString(jsonString)
+                .SetBoxApiUri(exampleUri)
+                .Build();
             Assert.AreEqual(config.BoxApiUri, exampleUri);
         }
 
@@ -49,7 +53,8 @@ namespace Box.V2.Test.Integration
               'webhooks': {},
               'enterpriseID': 'eid-123'
             }";
-            var config = BoxConfig.CreateFromJsonString(jsonString);
+            var config = BoxConfigBuilder.CreateFromJsonString(jsonString)
+                .Build();
 
             Assert.AreEqual(config.ClientId, "cid-123");
             Assert.AreEqual(config.ClientSecret, "cre-123");

--- a/Box.V2.Test.Integration/BoxFoldersManagerTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxFoldersManagerTestIntegration.cs
@@ -32,7 +32,9 @@ namespace Box.V2.Test.Integration
         [TestMethod]
         public async Task GetFolder_LiveSession_ValidResponse_GzipCompression()
         {
-            var boxConfig = new BoxConfig(ClientId, ClientSecret, RedirectUri){AcceptEncoding = CompressionType.gzip};
+            var boxConfig = new BoxConfigBuilder(ClientId, ClientSecret, RedirectUri)
+                .SetAcceptEncoding(CompressionType.gzip)
+                .Build();
             var boxClient = new BoxClient(boxConfig, _auth);
             await AssertFolderContents(boxClient);
         }
@@ -40,7 +42,9 @@ namespace Box.V2.Test.Integration
         [TestMethod]
         public async Task GetFolder_LiveSession_ValidResponse_DeflateCompression()
         {
-            var boxConfig = new BoxConfig(ClientId, ClientSecret, RedirectUri) { AcceptEncoding = CompressionType.deflate };
+            var boxConfig = new BoxConfigBuilder(ClientId, ClientSecret, RedirectUri)
+                .SetAcceptEncoding(CompressionType.deflate)
+                .Build();
             var boxClient = new BoxClient(boxConfig, _auth);
             await AssertFolderContents(boxClient);
         }

--- a/Box.V2.Test.Integration/BoxResourceManagerTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxResourceManagerTestIntegration.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using System.Diagnostics;
 using Box.V2.Auth;
@@ -44,7 +44,8 @@ namespace Box.V2.Test.Integration
             {
                 Debug.WriteLine("json config content length : " + jsonConfig.Length);
 
-                var config = BoxConfig.CreateFromJsonString(jsonConfig);
+                var config = BoxConfigBuilder.CreateFromJsonString(jsonConfig)
+                    .Build();
                 var session = new BoxJWTAuth(config);
 
                 // create a new app user
@@ -99,12 +100,14 @@ namespace Box.V2.Test.Integration
                 // Legacy way of getting the token
                 _auth = new OAuthSession("YOUR_ACCESS_TOKEN", "YOUR_REFRESH_TOKEN", 3600, "bearer");
 
-                _config = new BoxConfig(ClientId, ClientSecret, RedirectUri);
+                _config = new BoxConfigBuilder(ClientId, ClientSecret, RedirectUri)
+                    .Build();
                 _client = new BoxClient(_config, _auth);
             }
             else
             {
-                _config = BoxConfig.CreateFromJsonString(jsonConfig);
+                _config = BoxConfigBuilder.CreateFromJsonString(jsonConfig)
+                    .Build();
 
                 _client = userClient;
                 _auth = new OAuthSession(userToken, "", 3600, "bearer");

--- a/Box.V2.Test.Integration/BoxTokenExchangeTestIntegration.cs
+++ b/Box.V2.Test.Integration/BoxTokenExchangeTestIntegration.cs
@@ -1,4 +1,4 @@
-﻿using Box.V2.Auth;
+using Box.V2.Auth;
 using Box.V2.Auth.Token;
 using Box.V2.Config;
 using Box.V2.Exceptions;
@@ -16,7 +16,8 @@ namespace Box.V2.Test.Integration
         {
             var auth = new OAuthSession(token, "YOUR_REFRESH_TOKEN", 3600, "bearer");
 
-            var config = new BoxConfig(string.Empty, string.Empty, new Uri("http://boxsdk"));
+            var config = new BoxConfigBuilder(string.Empty, string.Empty, new Uri("http://boxsdk"))
+                .Build();
             var client = new BoxClient(config, auth);
 
             return client;

--- a/Box.V2.Test/AuthRepositoryTest.cs
+++ b/Box.V2.Test/AuthRepositoryTest.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using Box.V2.Services;
 using System.Threading.Tasks;
@@ -23,7 +23,7 @@ namespace Box.V2.Test
             // Arrange
             IRequestHandler handler = new HttpRequestHandler();
             IBoxService service = new BoxService(handler);
-            IBoxConfig config = new BoxConfig(null, null, null);
+            IBoxConfig config = new BoxConfigBuilder(null, null, null).Build();
 
             IAuthRepository authRepository = new AuthRepository(config, service, Converter);
 

--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -64,6 +64,7 @@
     <Compile Include="Auth\Token\ActorTokenBuilder.cs" />
     <Compile Include="Auth\Token\TokenExchange.cs" />
     <Compile Include="BoxClient.cs" />
+    <Compile Include="Config\BoxConfigBuilder.cs" />
     <Compile Include="IBoxClient.cs" />
     <Compile Include="Converter\BoxZipConflictConverter.cs" />
     <Compile Include="JWTAuth\BoxJWTAuth.cs" />

--- a/Box.V2/Config/BoxConfig.cs
+++ b/Box.V2/Config/BoxConfig.cs
@@ -7,9 +7,9 @@ using System.Text;
 
 namespace Box.V2.Config
 {
-    public class BoxConfig : IBoxConfig
+    public sealed class BoxConfig : IBoxConfig
     {
-        private static string DefaultUserAgent = "Box Windows SDK v" + AssemblyInfo.NuGetVersion;
+        internal static string DefaultUserAgent = "Box Windows SDK v" + AssemblyInfo.NuGetVersion;
 
         /// <summary>
         /// Instantiates a Box config with all of the standard defaults
@@ -44,6 +44,26 @@ namespace Box.V2.Config
             JWTPrivateKeyPassword = jwtPrivateKeyPassword;
             JWTPublicKeyId = jwtPublicKeyId;
             UserAgent = DefaultUserAgent;
+        }
+
+        public BoxConfig(BoxConfigBuilder builder)
+        {
+            ClientId = builder.ClientId;
+            ClientSecret = builder.ClientSecret;
+            EnterpriseId = builder.EnterpriseId;
+            JWTPrivateKey = builder.JWTPrivateKey;
+            JWTPrivateKeyPassword = builder.JWTPrivateKeyPassword;
+            JWTPublicKeyId = builder.JWTPublicKeyId;
+            UserAgent = builder.UserAgent;
+            BoxApiHostUri = builder.BoxApiHostUri;
+            BoxAccountApiHostUri = builder.BoxAccountApiHostUri;
+            BoxApiUri = builder.BoxApiUri;
+            BoxUploadApiUri = builder.BoxUploadApiUri;
+            RedirectUri = builder.RedirectUri;
+            DeviceId = builder.DeviceId;
+            DeviceName = builder.DeviceName;
+            AcceptEncoding = builder.AcceptEncoding;
+            WebProxy = builder.WebProxy;
         }
 
         /// <summary>
@@ -122,67 +142,67 @@ namespace Box.V2.Config
             return new BoxConfig(clientId, clientSecret, enterpriseId, privateKey, rsaSecret, publicKeyId);
         }
 
-        public virtual Uri BoxApiHostUri { get; set; } = new Uri(Constants.BoxApiHostUriString);
-        public virtual Uri BoxAccountApiHostUri { get; set; } = new Uri(Constants.BoxAccountApiHostUriString);
-        public virtual Uri BoxApiUri { get; set; } = new Uri(Constants.BoxApiUriString);
-        public virtual Uri BoxUploadApiUri { get; set; } = new Uri(Constants.BoxUploadApiUriString);
+        public Uri BoxApiHostUri { get; private set; } = new Uri(Constants.BoxApiHostUriString);
+        public Uri BoxAccountApiHostUri { get; private set; } = new Uri(Constants.BoxAccountApiHostUriString);
+        public Uri BoxApiUri { get; private set; } = new Uri(Constants.BoxApiUriString);
+        public Uri BoxUploadApiUri { get; private set; } = new Uri(Constants.BoxUploadApiUriString);
 
-        public virtual string ClientId { get; private set; }
-        public virtual string ConsumerKey { get; private set; }
-        public virtual string ClientSecret { get; private set; }
-        public virtual Uri RedirectUri { get; set; }
+        public string ClientId { get; private set; }
+        public string ConsumerKey { get; private set; }
+        public string ClientSecret { get; private set; }
+        public Uri RedirectUri { get; private set; }
 
         public string EnterpriseId { get; private set; }
         public string JWTPrivateKey { get; private set; }
         public string JWTPrivateKeyPassword { get; private set; }
         public string JWTPublicKeyId { get; private set; }
 
-        public string DeviceId { get; set; }
-        public string DeviceName { get; set; }
-        public string UserAgent { get; set; }
+        public string DeviceId { get; private set; }
+        public string DeviceName { get; private set; }
+        public string UserAgent { get; private set; }
 
         /// <summary>
         /// Sends compressed responses from Box for faster response times
         /// </summary>
-        public CompressionType? AcceptEncoding { get; set; }
+        public CompressionType? AcceptEncoding { get; private set; }
 
-        public virtual Uri AuthCodeBaseUri { get { return new Uri(BoxAccountApiHostUri, Constants.AuthCodeString); } }
-        public virtual Uri AuthCodeUri { get { return new Uri(AuthCodeBaseUri, string.Format("?response_type=code&client_id={0}&redirect_uri={1}", ClientId, RedirectUri)); } }
-        public virtual Uri FoldersEndpointUri { get { return new Uri(BoxApiUri, Constants.FoldersString); } }
-        public virtual Uri TermsOfServicesUri { get { return new Uri(BoxApiUri, Constants.TermsOfServicesString); } }
-        public virtual Uri TermsOfServiceUserStatusesUri { get { return new Uri(BoxApiUri, Constants.TermsOfServiceUserStatusesString); } }
-        public virtual Uri FilesEndpointUri { get { return new Uri(BoxApiUri, Constants.FilesString); } }
-        public virtual Uri FilesUploadEndpointUri { get { return new Uri(BoxUploadApiUri, Constants.FilesUploadString); } }
+        public Uri AuthCodeBaseUri { get { return new Uri(BoxAccountApiHostUri, Constants.AuthCodeString); } }
+        public Uri AuthCodeUri { get { return new Uri(AuthCodeBaseUri, string.Format("?response_type=code&client_id={0}&redirect_uri={1}", ClientId, RedirectUri)); } }
+        public Uri FoldersEndpointUri { get { return new Uri(BoxApiUri, Constants.FoldersString); } }
+        public Uri TermsOfServicesUri { get { return new Uri(BoxApiUri, Constants.TermsOfServicesString); } }
+        public Uri TermsOfServiceUserStatusesUri { get { return new Uri(BoxApiUri, Constants.TermsOfServiceUserStatusesString); } }
+        public Uri FilesEndpointUri { get { return new Uri(BoxApiUri, Constants.FilesString); } }
+        public Uri FilesUploadEndpointUri { get { return new Uri(BoxUploadApiUri, Constants.FilesUploadString); } }
 
         /// <summary>
         /// Upload session
         /// </summary>
-        public virtual Uri FilesUploadSessionEndpointUri { get { return new Uri(BoxUploadApiUri, Constants.FilesUploadSessionString); } }
-        public virtual Uri FilesPreflightCheckUri { get { return new Uri(BoxApiUri, Constants.FilesUploadString); } }
-        public virtual Uri CommentsEndpointUri { get { return new Uri(BoxApiUri, Constants.CommentsString); } }
-        public virtual Uri SearchEndpointUri { get { return new Uri(BoxApiUri, Constants.SearchString); } }
-        public virtual Uri UserEndpointUri { get { return new Uri(BoxApiUri, Constants.UserString); } }
-        public virtual Uri InviteEndpointUri { get { return new Uri(BoxApiUri, Constants.InviteString); } }
-        public virtual Uri CollaborationsEndpointUri { get { return new Uri(BoxApiUri, Constants.CollaborationsString); } }
-        public virtual Uri GroupsEndpointUri { get { return new Uri(BoxApiUri, Constants.GroupsString); } }
-        public virtual Uri GroupMembershipEndpointUri { get { return new Uri(BoxApiUri, Constants.GroupMembershipString); } }
-        public virtual Uri RetentionPoliciesEndpointUri { get { return new Uri(BoxApiUri, Constants.RetentionPoliciesString); } }
-        public virtual Uri RetentionPolicyAssignmentsUri { get { return new Uri(BoxApiUri, Constants.RetentionPolicyAssignmentsString); } }
-        public virtual Uri FileVersionRetentionsUri { get { return new Uri(BoxApiUri, Constants.FileVersionRetentionsString); } }
-        public virtual Uri EventsUri { get { return new Uri(BoxApiUri, Constants.EventsString); } }
-        public virtual Uri MetadataTemplatesUri { get { return new Uri(BoxApiUri, Constants.MetadataTemplatesString); } }
-        public virtual Uri CreateMetadataTemplateUri { get { return new Uri(BoxApiUri, Constants.CreateMetadataTemplateString); } }
-        public virtual Uri MetadataQueryUri { get { return new Uri(BoxApiUri, Constants.MetadataQueryString); } }
-        public virtual Uri WebhooksUri { get { return new Uri(BoxApiUri, Constants.WebhooksString); } }
-        public virtual Uri RecentItemsUri { get { return new Uri(BoxApiUri, Constants.RecentItemsString); } }
-        public virtual Uri EnterprisesUri { get { return new Uri(BoxApiUri, Constants.EnterprisesString); } }
-        public virtual Uri DevicePinUri { get { return new Uri(BoxApiUri, Constants.DevicePinString); } }
-        public virtual Uri CollaborationWhitelistEntryUri { get { return new Uri(BoxApiUri, Constants.CollaborationWhitelistEntryString); } }
-        public virtual Uri CollaborationWhitelistTargetEntryUri { get { return new Uri(BoxApiUri, Constants.CollaborationWhitelistTargetEntryString); } }
-        public virtual Uri MetadataCascadePolicyUri { get { return new Uri(BoxApiUri, Constants.MetadataCascadePoliciesString); } }
-        public virtual Uri StoragePoliciesUri { get { return new Uri(BoxApiUri, Constants.StoragePoliciesString); } }
-        public virtual Uri StoragePolicyAssignmentsUri { get { return new Uri(BoxApiUri, Constants.StoragePolicyAssignmentsString); } }
-        public virtual Uri StoragePolicyAssignmentsForTargetUri { get { return new Uri(BoxApiUri, Constants.StoragePolicyAssignmentsForTargetString); } }
+        public Uri FilesUploadSessionEndpointUri { get { return new Uri(BoxUploadApiUri, Constants.FilesUploadSessionString); } }
+        public Uri FilesPreflightCheckUri { get { return new Uri(BoxApiUri, Constants.FilesUploadString); } }
+        public Uri CommentsEndpointUri { get { return new Uri(BoxApiUri, Constants.CommentsString); } }
+        public Uri SearchEndpointUri { get { return new Uri(BoxApiUri, Constants.SearchString); } }
+        public Uri UserEndpointUri { get { return new Uri(BoxApiUri, Constants.UserString); } }
+        public Uri InviteEndpointUri { get { return new Uri(BoxApiUri, Constants.InviteString); } }
+        public Uri CollaborationsEndpointUri { get { return new Uri(BoxApiUri, Constants.CollaborationsString); } }
+        public Uri GroupsEndpointUri { get { return new Uri(BoxApiUri, Constants.GroupsString); } }
+        public Uri GroupMembershipEndpointUri { get { return new Uri(BoxApiUri, Constants.GroupMembershipString); } }
+        public Uri RetentionPoliciesEndpointUri { get { return new Uri(BoxApiUri, Constants.RetentionPoliciesString); } }
+        public Uri RetentionPolicyAssignmentsUri { get { return new Uri(BoxApiUri, Constants.RetentionPolicyAssignmentsString); } }
+        public Uri FileVersionRetentionsUri { get { return new Uri(BoxApiUri, Constants.FileVersionRetentionsString); } }
+        public Uri EventsUri { get { return new Uri(BoxApiUri, Constants.EventsString); } }
+        public Uri MetadataTemplatesUri { get { return new Uri(BoxApiUri, Constants.MetadataTemplatesString); } }
+        public Uri CreateMetadataTemplateUri { get { return new Uri(BoxApiUri, Constants.CreateMetadataTemplateString); } }
+        public Uri MetadataQueryUri { get { return new Uri(BoxApiUri, Constants.MetadataQueryString); } }
+        public Uri WebhooksUri { get { return new Uri(BoxApiUri, Constants.WebhooksString); } }
+        public Uri RecentItemsUri { get { return new Uri(BoxApiUri, Constants.RecentItemsString); } }
+        public Uri EnterprisesUri { get { return new Uri(BoxApiUri, Constants.EnterprisesString); } }
+        public Uri DevicePinUri { get { return new Uri(BoxApiUri, Constants.DevicePinString); } }
+        public Uri CollaborationWhitelistEntryUri { get { return new Uri(BoxApiUri, Constants.CollaborationWhitelistEntryString); } }
+        public Uri CollaborationWhitelistTargetEntryUri { get { return new Uri(BoxApiUri, Constants.CollaborationWhitelistTargetEntryString); } }
+        public Uri MetadataCascadePolicyUri { get { return new Uri(BoxApiUri, Constants.MetadataCascadePoliciesString); } }
+        public Uri StoragePoliciesUri { get { return new Uri(BoxApiUri, Constants.StoragePoliciesString); } }
+        public Uri StoragePolicyAssignmentsUri { get { return new Uri(BoxApiUri, Constants.StoragePolicyAssignmentsString); } }
+        public Uri StoragePolicyAssignmentsForTargetUri { get { return new Uri(BoxApiUri, Constants.StoragePolicyAssignmentsForTargetString); } }
 
         /// <summary>
         /// Gets the shared items endpoint URI.
@@ -190,7 +210,7 @@ namespace Box.V2.Config
         /// <value>
         /// The shared items endpoint URI.
         /// </value>
-        public virtual Uri SharedItemsUri { get { return new Uri(BoxApiUri, Constants.SharedItemsString); } }
+        public Uri SharedItemsUri { get { return new Uri(BoxApiUri, Constants.SharedItemsString); } }
 
         /// <summary>
         /// Gets the task assignments endpoint URI.
@@ -198,12 +218,12 @@ namespace Box.V2.Config
         /// <value>
         /// The task assignments endpoint URI.
         /// </value>
-        public virtual Uri TaskAssignmentsEndpointUri { get { return new Uri(BoxApiUri, Constants.TaskAssignmentsString); } }
+        public Uri TaskAssignmentsEndpointUri { get { return new Uri(BoxApiUri, Constants.TaskAssignmentsString); } }
 
         /// <summary>
         /// Gets the tasks endpoint URI.
         /// </summary>
-        public virtual Uri TasksEndpointUri { get { return new Uri(BoxApiUri, Constants.TasksString); } }
+        public Uri TasksEndpointUri { get { return new Uri(BoxApiUri, Constants.TasksString); } }
 
         /// <summary>
         /// Gets the collections endpoint URI.
@@ -211,35 +231,35 @@ namespace Box.V2.Config
         /// <value>
         /// The collections endpoint URI.
         /// </value>
-        public virtual Uri CollectionsEndpointUri { get { return new Uri(BoxApiUri, Constants.CollectionsString); } }
+        public Uri CollectionsEndpointUri { get { return new Uri(BoxApiUri, Constants.CollectionsString); } }
         /// <summary>
         /// Gets the web links endpoint URI.
         /// </summary>
-        public virtual Uri WebLinksEndpointUri { get { return new Uri(BoxApiUri, Constants.WebLinksString); } }
+        public Uri WebLinksEndpointUri { get { return new Uri(BoxApiUri, Constants.WebLinksString); } }
         /// <summary>
         /// Gets the legal hold policies endpoint URI.
         /// </summary>
-        public virtual Uri LegalHoldPoliciesEndpointUri { get { return new Uri(BoxApiUri, Constants.LegalHoldPoliciesString); } }
+        public Uri LegalHoldPoliciesEndpointUri { get { return new Uri(BoxApiUri, Constants.LegalHoldPoliciesString); } }
         /// <summary>
         /// Gets the legal hold policies endpoint URI.
         /// </summary>
-        public virtual Uri LegalHoldPolicyAssignmentsEndpointUri { get { return new Uri(BoxApiUri, Constants.LegalHoldPolicyAssignmentsString); } }
+        public Uri LegalHoldPolicyAssignmentsEndpointUri { get { return new Uri(BoxApiUri, Constants.LegalHoldPolicyAssignmentsString); } }
         /// <summary>
         /// Gets the file viersion legal holds endpoint URI.
         /// </summary>
-        public virtual Uri FileVersionLegalHoldsEndpointUri { get { return new Uri(BoxApiUri, Constants.FileVersionLegalHoldsString); } }
+        public Uri FileVersionLegalHoldsEndpointUri { get { return new Uri(BoxApiUri, Constants.FileVersionLegalHoldsString); } }
         /// <summary>
         /// Gets the zip downloads endpoint URI.
         /// </summary>
-        public virtual Uri ZipDownloadsEndpointUri { get { return new Uri(BoxApiUri, Constants.ZipDownloadsString); } }
+        public Uri ZipDownloadsEndpointUri { get { return new Uri(BoxApiUri, Constants.ZipDownloadsString); } }
         /// <summary>
         /// Gets the folder locks endpoint URI.
         /// </summary>
-        public virtual Uri FolderLocksEndpointUri { get { return new Uri(BoxApiUri, Constants.FolderLocksString); } }
+        public Uri FolderLocksEndpointUri { get { return new Uri(BoxApiUri, Constants.FolderLocksString); } }
         /// <summary>
         /// The web proxy for HttpRequestHandler
         /// </summary>
-        public IWebProxy WebProxy { get; set; }
+        public IWebProxy WebProxy { get; private set; }
     }
 
     public enum CompressionType

--- a/Box.V2/Config/BoxConfigBuilder.cs
+++ b/Box.V2/Config/BoxConfigBuilder.cs
@@ -1,0 +1,234 @@
+using System;
+using System.IO;
+using System.Net;
+
+namespace Box.V2.Config
+{
+    /// <summary>
+    /// Builder used to instantiate new BoxConfig. It follows FluentBuilder pattern and can be used by chaining methods.
+    /// </summary>
+    public class BoxConfigBuilder
+    {
+        /// <summary>
+        /// Instantiates a BoxConfigBuilder with all of the standard defaults
+        /// </summary>
+        /// <param name="clientId"></param>
+        /// <param name="clientSecret"></param>
+        /// <param name="redirectUri"></param>
+        /// <returns>BoxConfigBuilder instance.</returns>
+        public BoxConfigBuilder(string clientId, string clientSecret, Uri redirectUri)
+        {
+            ClientId = clientId;
+            ClientSecret = clientSecret;
+            RedirectUri = redirectUri;
+            UserAgent = BoxConfig.DefaultUserAgent;
+        }
+
+        /// <summary>
+        /// Instantiates a BoxConfigBuilder for use with JWT authentication
+        /// </summary>
+        /// <param name="clientId"></param>
+        /// <param name="clientSecret"></param>
+        /// <param name="enterpriseId"></param>
+        /// <param name="jwtPrivateKey"></param>
+        /// <param name="jwtPrivateKeyPassword"></param>
+        /// <param name="jwtPublicKeyId"></param>
+        /// <returns>BoxConfigBuilder instance.</returns>
+        public BoxConfigBuilder(string clientId, string clientSecret, string enterpriseId,
+            string jwtPrivateKey, string jwtPrivateKeyPassword, string jwtPublicKeyId)
+        {
+            ClientId = clientId;
+            ClientSecret = clientSecret;
+            EnterpriseId = enterpriseId;
+            JWTPrivateKey = jwtPrivateKey;
+            JWTPrivateKeyPassword = jwtPrivateKeyPassword;
+            JWTPublicKeyId = jwtPublicKeyId;
+            UserAgent = BoxConfig.DefaultUserAgent;
+        }
+
+        /// <summary>
+        /// Create BoxConfigBuilder from json file.
+        /// </summary>
+        /// <param name="jsonFile">json file stream.</param>
+        /// <returns>BoxConfigBuilder instance.</returns>
+        public static BoxConfigBuilder CreateFromJsonFile(Stream jsonFile)
+        {
+            var config = BoxConfig.CreateFromJsonFile(jsonFile);
+            var configBuilder = new BoxConfigBuilder();
+            RewritePropertiesToBuilder(configBuilder, config);
+            return configBuilder;
+        }
+
+        /// <summary>
+        /// Create BoxConfigBuilder from json string
+        /// </summary>
+        /// <param name="jsonString">json string.</param>
+        /// <returns>BoxConfigBuilder instance.</returns>
+        public static BoxConfigBuilder CreateFromJsonString(string jsonString)
+        {
+            var config = BoxConfig.CreateFromJsonString(jsonString);
+            var configBuilder = new BoxConfigBuilder();
+            RewritePropertiesToBuilder(configBuilder, config);
+            return configBuilder;
+        }
+
+        private static void RewritePropertiesToBuilder(BoxConfigBuilder configBuilder, IBoxConfig config)
+        {
+            configBuilder.ClientId = config.ClientId;
+            configBuilder.ClientSecret = config.ClientSecret;
+            configBuilder.JWTPrivateKey = config.JWTPrivateKey;
+            configBuilder.JWTPrivateKeyPassword = config.JWTPrivateKeyPassword;
+            configBuilder.JWTPublicKeyId = config.JWTPublicKeyId;
+            configBuilder.EnterpriseId = config.EnterpriseId;
+        }
+
+        private BoxConfigBuilder() { }
+
+        /// <summary>
+        /// Create IBoxConfig from the builder.
+        /// </summary>
+        /// <returns>IBoxConfig instance.</returns>
+        public IBoxConfig Build()
+        {
+            return new BoxConfig(this);
+        }
+
+        /// <summary>
+        /// Sets user agent.
+        /// </summary>
+        /// <param name="userAgent">User agent.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetUserAgent(string userAgent)
+        {
+            UserAgent = userAgent;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets BoxAPI host uri.
+        /// </summary>
+        /// <param name="boxApiHostUri">BoxAPI host uri.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetBoxApiHostUri(Uri boxApiHostUri)
+        {
+            BoxApiHostUri = boxApiHostUri;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets BoxAPI account host uri.
+        /// </summary>
+        /// <param name="boxAccountApiHostUri">BoxAPI account host uri.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetBoxAccountApiHostUri(Uri boxAccountApiHostUri)
+        {
+            BoxAccountApiHostUri = boxAccountApiHostUri;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets BoxAPI uri.
+        /// </summary>
+        /// <param name="boxApiUri">BoxAPI uri.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetBoxApiUri(Uri boxApiUri)
+        {
+            BoxApiUri = boxApiUri;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets BoxAPI upload uri.
+        /// </summary>
+        /// <param name="boxUploadApiUri">BoxAPI upload uri.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetBoxUploadApiUri(Uri boxUploadApiUri)
+        {
+            BoxUploadApiUri = boxUploadApiUri;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets redirect uri.
+        /// </summary>
+        /// <param name="redirectUri">Redirect uri.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetRedirectUri(Uri redirectUri)
+        {
+            RedirectUri = redirectUri;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets device id.
+        /// </summary>
+        /// <param name="deviceId">Device id.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetDeviceId(string deviceId)
+        {
+            DeviceId = deviceId;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets device name.
+        /// </summary>
+        /// <param name="deviceName">Device name.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetDeviceName(string deviceName)
+        {
+            DeviceName = deviceName;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets acceptEncoding.
+        /// </summary>
+        /// <param name="acceptEncoding">AcceptEncoding.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetAcceptEncoding(CompressionType? acceptEncoding)
+        {
+            AcceptEncoding = acceptEncoding;
+            return this;
+        }
+
+        /// <summary>
+        /// Sets web proxy for HttpRequestHandler.
+        /// </summary>
+        /// <param name="webProxy">Web proxy for HttpRequestHandler.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetWebProxy(IWebProxy webProxy)
+        {
+            WebProxy = webProxy;
+            return this;
+        }
+
+        public string ClientId { get; private set; }
+        public string ClientSecret { get; private set; }
+        public string EnterpriseId { get; private set; }
+        public string JWTPrivateKey { get; private set; }
+        public string JWTPrivateKeyPassword { get; private set; }
+        public string JWTPublicKeyId { get; private set; }
+        public string UserAgent { get; private set; }
+
+
+        public Uri BoxApiHostUri { get; private set; } = new Uri(Constants.BoxApiHostUriString);
+        public Uri BoxAccountApiHostUri { get; private set; } = new Uri(Constants.BoxAccountApiHostUriString);
+        public Uri BoxApiUri { get; private set; } = new Uri(Constants.BoxApiUriString);
+        public Uri BoxUploadApiUri { get; private set; } = new Uri(Constants.BoxUploadApiUriString);
+
+        public Uri RedirectUri { get; private set; }
+        public string DeviceId { get; private set; }
+        public string DeviceName { get; private set; }
+
+        /// <summary>
+        /// Sends compressed responses from Box for faster response times
+        /// </summary>
+        public CompressionType? AcceptEncoding { get; private set; }
+
+        /// <summary>
+        /// The web proxy for HttpRequestHandler
+        /// </summary>
+        public IWebProxy WebProxy { get; private set; }
+    }
+}

--- a/Box.V2/Config/IBoxConfig.cs
+++ b/Box.V2/Config/IBoxConfig.cs
@@ -5,9 +5,10 @@ namespace Box.V2.Config
 {
     public interface IBoxConfig
     {
-        Uri BoxApiHostUri { get; set; }
-        Uri BoxApiUri { get; set; }
-        Uri BoxUploadApiUri { get; set; }
+        Uri BoxApiHostUri { get; }
+        Uri BoxAccountApiHostUri { get; }
+        Uri BoxApiUri { get; }
+        Uri BoxUploadApiUri { get; }
 
         string ClientId { get; }
         string ConsumerKey { get; }
@@ -19,9 +20,9 @@ namespace Box.V2.Config
         string JWTPrivateKeyPassword { get; }
         string JWTPublicKeyId { get; }
 
-        string DeviceId { get; set; }
-        string DeviceName { get; set; }
-        string UserAgent { get; set; }
+        string DeviceId { get; }
+        string DeviceName { get; }
+        string UserAgent { get; }
 
         /// <summary>
         /// Sends compressed responses from Box for faster response times
@@ -40,7 +41,6 @@ namespace Box.V2.Config
         Uri FilesUploadSessionEndpointUri { get; }
 
         Uri FilesPreflightCheckUri { get; }
-        //Uri FilesPreflightCheckNewVersionUri { get; }
         Uri CommentsEndpointUri { get; }
         Uri SearchEndpointUri { get; }
         Uri UserEndpointUri { get; }
@@ -123,6 +123,6 @@ namespace Box.V2.Config
         /// <summary>
         /// The web proxy for HttpRequestHandler
         /// </summary>
-        IWebProxy WebProxy { get; set; }
+        IWebProxy WebProxy { get; }
     }
 }

--- a/Box.V2/JWTAuth/BoxJWTAuth.cs
+++ b/Box.V2/JWTAuth/BoxJWTAuth.cs
@@ -54,7 +54,7 @@ namespace Box.V2.JWTAuth
             // the following allows creation of a BoxJWTAuth object without valid keys but with a valid JWT UserToken
             // this allows code like this:
 
-            // var boxConfig = new BoxConfig("", "", "", "", "", "");
+            // var boxConfig = new BoxConfigBuilder("", "", "", "", "", "").Build();
             // var boxJwt = new BoxJWTAuth(boxConfig);
             // const string userToken = "TOKEN_OBTAINED_BY_CALLING_FULL_BOXJWTAUTH";  // token valid for 1 hr.
             // UserClient = boxJwt.UserClient(userToken, null);  // this user client can do normal file operations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Breaking changes:**
 - Extract interfaces for BoxClient and Managers to improve testability ([#603](https://github.com/box/box-windows-sdk-v2/pull/603))
+- Add BoxConfigBuilder and make BoxConfig immutable ([#737](https://github.com/box/box-windows-sdk-v2/pull/737))
 
 **New Features and Enhancements:**
 - Add ability to get files under retention for assignment and file versions under retention for assignment ([#734](https://github.com/box/box-windows-sdk-v2/pull/734))

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ If you haven't already created an app in Box go to https://developer.box.com/ an
 
 #### Using a Developer Token (generate one in your app admin console; they last for 60 minutes)
 ```c#
-var config = new BoxConfig(<Client_Id>, <Client_Secret>, new Uri("http://localhost"));
+var config = new BoxConfigBuilder(<Client_Id>, <Client_Secret>, new Uri("http://localhost")).Build();
 var session = new OAuthSession(<Developer_Token>, "NOT_NEEDED", 3600, "bearer");
 client = new BoxClient(config, session);
 ```
@@ -56,7 +56,7 @@ Allow Box Managed Users to share and collaboration with external users via Box a
 
 ##### Configure
 ```c#
-var boxConfig = new BoxConfig(<Client_Id>, <Client_Secret>, <Enterprise_Id>, <Private_Key>, <JWT_Private_Key_Password>, <JWT_Public_Key_Id>);
+var boxConfig = new BoxConfigBuilder(<Client_Id>, <Client_Secret>, <Enterprise_Id>, <Private_Key>, <JWT_Private_Key_Password>, <JWT_Public_Key_Id>).	Build();
 var boxJWT = new BoxJWTAuth(boxConfig);
 ```
 
@@ -89,7 +89,7 @@ This is a three-legged authentication process to allow managed user and external
 ##### Configure
 Set your configuration parameters and initialize the client:
 ```c#
-var config = new BoxConfig(<Client_Id>, <Client_Secret>, <Redirect_Uri>);
+var config = new BoxConfigBuilder(<Client_Id>, <Client_Secret>, <Redirect_Uri>).Build();
 var client = new BoxClient(config);
 ```
 
@@ -132,7 +132,7 @@ this method of aythentication, simply create a client with only the API key and
 access token provided:
 
 ```c#
-var config = new BoxConfig(<API_KEY>, "", new Uri("http://localhost"));
+var config = new BoxConfigBuilder(<API_KEY>, "", new Uri("http://localhost")).Build();
 var session = new OAuthSession(<PRIMARY OR SECONDARY TOKEN>, "NOT_NEEDED", 3600, "bearer");
 client = new BoxClient(config, session);
 ```
@@ -274,7 +274,7 @@ var results = await client.SearchManager.SearchAsync(mdFilters: new List<BoxMeta
 If you have an admin token with appropriate permissions, you can make API calls in the context of a managed user. In order to do this you must request Box.com to activate As-User functionality for your API key (see developer site for instructions). 
 
 ```c#
-var config = new BoxConfig(<Client_Id>, <Client_Secret>, <Redirect_Uri);
+var config = new BoxConfigBuilder(<Client_Id>, <Client_Secret>, <Redirect_Uri).Build();
 var auth = new OAuthSession(<Your_Access_Token>, <Your_Refresh_Token>, 3600, "bearer");
 
 var userId = "12345678"
@@ -289,7 +289,7 @@ var items  = await userClient.FoldersManager.GetFolderItemsAsync("0", 500);
 Using the admin token we can make a call to retrieve all users or a specific user
 
 ```cs
-var boxConfig = new BoxConfig(<Client_Id>, <Client_Secret>, <Enterprise_Id>, <Private_Key>, <JWT_Private_Key_Password>, <JWT_Public_Key_Id>);
+var boxConfig = new BoxConfigBuilder(<Client_Id>, <Client_Secret>, <Enterprise_Id>, <Private_Key>, <JWT_Private_Key_Password>, <JWT_Public_Key_Id>).	Build();
 var boxJWT = new BoxJWTAuth(boxConfig);
 
 var adminToken = boxJWT.AdminToken();
@@ -324,7 +324,7 @@ foreach(BoxItem item in boxFolderItemsList)
 #### Suppressing Notifications
 If you are making administrative API calls (that is, your application has “Manage an Enterprise” scope, and the user making the API call is a co-admin with the correct "Edit settings for your company" permission) then you can suppress both email and webhook notifications.
 ```c#
-var config = new BoxConfig(<Client_Id>, <Client_Secret>, <Redirect_Uri);
+var config = new BoxConfigBuilder(<Client_Id>, <Client_Secret>, <Redirect_Uri).Build();
 var auth = new OAuthSession(<Your_Access_Token>, <Your_Refresh_Token>, 3600, "bearer");
 
 var adminClient = new BoxClient(config, auth, suppressNotifications: true);

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -62,18 +62,18 @@ Service Account:
 
 <!-- sample x_auth init_with_jwt_enterprise -->
 ```c#
-var config = BoxConfig.CreateFromJsonString(jsonConfig);
+var config = BoxConfigBuilder.CreateFromJsonString(jsonConfig).Build();
 var session = new BoxJWTAuth(config);
 var adminToken = session.AdminToken(); //valid for 60 minutes so should be cached and re-used
 BoxClient adminClient = session.AdminClient(adminToken);
 ```
 
 Otherwise, you'll need to provide the necessary configuration fields directly
-to the `BoxConfig` constructor:
+to the `BoxConfigBuilder` constructor:
 
 <!-- sample x_auth init_with_jwt_enterprise_with_config -->
 ```c#
-var boxConfig = new BoxConfig("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET", "YOUR_ENTERPRISE_ID", "ENCRYPTED_PRIVATE_KEY", "PRIVATE_KEY_PASSWORD", "PUBLIC_KEY_ID");
+var boxConfig = new BoxConfigBuilder("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET", "YOUR_ENTERPRISE_ID", "ENCRYPTED_PRIVATE_KEY", "PRIVATE_KEY_PASSWORD", "PUBLIC_KEY_ID").Build();
 var boxJWT = new BoxJWTAuth(boxConfig);
 var adminToken = boxJWT.AdminToken(); //valid for 60 minutes so should be cached and re-used
 BoxClient adminClient = boxJWT.AdminClient(adminToken);
@@ -128,7 +128,7 @@ client secret to establish an API connection.  The `BoxClient` will
 automatically refresh the access token as needed.
 
 ```c#
-var config = new BoxConfig("CLIENT_ID", "CLIENT_SECRET", new System.Uri("YOUR_REDIRECT_URL"));
+var config = new BoxConfigBuilder("CLIENT_ID", "CLIENT_SECRET", new System.Uri("YOUR_REDIRECT_URL")).Build();
 var client = new BoxClient(config);
 OAuthSession session = // Create session from custom implementation
 var client = new BoxClient(config, session);
@@ -155,7 +155,7 @@ simply create a basic client with that token:
 
 <!-- sample x_auth init_with_app_token -->
 ```c#
-var config = new BoxConfig("YOUR_CLIENT_ID", "N/A", new Uri("http://localhost"));
+var config = new BoxConfigBuilder("YOUR_CLIENT_ID", "N/A", new Uri("http://localhost")).Build();
 var session = new OAuthSession("YOUR_APP_TOKEN", "N/A", 3600, "bearer");
 var client = new BoxClient(config, session);
 ```

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -38,7 +38,7 @@ The following example creates an API client with a developer token:
 
 <!-- sample x_auth init_with_dev_token -->
 ```c#
-var config = new BoxConfig("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET", new Uri("http://localhost"));
+var config = new BoxConfigBuilder("YOUR_CLIENT_ID", "YOUR_CLIENT_SECRET", new Uri("http://localhost")).Build();
 var session = new OAuthSession("YOUR_DEVELOPER_TOKEN", "N/A", 3600, "bearer");
 var client = new BoxClient(config, session);
 ```


### PR DESCRIPTION
I created BoxConfigBuilder to make it easier to create new BoxConfig (fluent builder, used in [.NET Core](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.configuration.configurationbuilder?view=dotnet-plat-ext-5.0) to build configuration so .NET devs should be familiar with this). 

At the same time BoxConfig was made immutable. I could also remove constructors from BoxConfig, but it would make it more 'breaking' that it is at the moment. To be discussed.