### PR TITLE
fix: http response disposed when it contains a stream

### DIFF
--- a/Box.V2/Request/HttpRequestHandler.cs
+++ b/Box.V2/Request/HttpRequestHandler.cs
@@ -69,9 +69,9 @@ namespace Box.V2.Request
                 while (true)
                 {
                     using (HttpRequestMessage httpRequest = GetHttpRequest(request, isMultiPartRequest, isBinaryRequest))
-                    using (HttpResponseMessage response = await GetResponse(request, isStream, httpRequest).ConfigureAwait(false))
                     {
                         Debug.WriteLine(string.Format("RequestUri: {0}", httpRequest.RequestUri));
+                        HttpResponseMessage response = await GetResponse(request, isStream, httpRequest).ConfigureAwait(false);
                         //need to wait for Retry-After seconds and then retry request
                         var retryAfterHeader = response.Headers.RetryAfter;
 


### PR DESCRIPTION
Introduced in #739. Fixes #762. We still dispose non-streaming responses in line 243.