### PR TITLE
fix: correctly pass null when rolling out user from the enterprise

### DIFF
--- a/Box.V2.Test/BoxUsersManagerTest.cs
+++ b/Box.V2.Test/BoxUsersManagerTest.cs
@@ -208,6 +208,39 @@ namespace Box.V2.Test
 
         [TestMethod]
         [TestCategory("CI-UNIT-TEST")]
+        public async Task RolloutUserFromEnterprise_ValidResponse_ValidUser()
+        {
+            /*** Arrange ***/
+            var responseString = "{\"type\":\"user\",\"id\":\"181216415\",\"name\":\"sean\",\"login\":\"sean+awesome@box.com\",\"created_at\":\"2012-05-03T21:39:11-07:00\",\"modified_at\":\"2012-12-06T18:17:16-08:00\",\"role\":\"admin\",\"language\":\"en\",\"space_amount\":5368709120,\"space_used\":1237179286,\"max_upload_size\":2147483648,\"tracking_codes\":[],\"can_see_managed_users\":true,\"is_sync_enabled\":true,\"status\":\"active\",\"job_title\":\"\",\"phone\":\"6509241374\",\"address\":\"\",\"avatar_url\":\"https://www.box.com/api/avatar/large/181216415\",\"is_exempt_from_device_limits\":false,\"is_exempt_from_login_verification\":false, \"notification_email\": { \"email\": \"test@example.com\", \"is_confirmed\": true}}";
+            IBoxRequest boxRequest = null;
+            Handler.Setup(h => h.ExecuteAsync<BoxUser>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxUser>>(new BoxResponse<BoxUser>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = responseString
+                }))
+                .Callback<IBoxRequest>(r => boxRequest = r);
+
+            /*** Act ***/
+            var userRequest = new BoxUserRollOutRequest()
+            {
+                Id = "181216415",
+            };
+            BoxUser user = await _usersManager.UpdateUserInformationAsync(userRequest);
+
+            /*** Assert ***/
+
+            // Request check
+            Assert.IsNotNull(boxRequest);
+            Assert.AreEqual(RequestMethod.Put, boxRequest.Method);
+            Assert.AreEqual(UserUri + "181216415", boxRequest.AbsoluteUri.AbsoluteUri);
+            BoxUserRequest payload = JsonConvert.DeserializeObject<BoxUserRequest>(boxRequest.Payload);
+            Assert.AreEqual(userRequest.Id, payload.Id);
+            Assert.AreEqual(boxRequest.Payload, "{\"enterprise\":null,\"id\":\"181216415\"}");
+        }
+
+        [TestMethod]
+        [TestCategory("CI-UNIT-TEST")]
         public async Task InviteUser_ValidResponse_ValidUser()
         {
             /*** Arrange ***/

--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -202,6 +202,7 @@
     <Compile Include="Models\Request\BoxFileUploadSessionRequest.cs" />
     <Compile Include="Models\Request\BoxSignRequestCreateRequest.cs" />
     <Compile Include="Models\Request\BoxTermsOfServiceUserStatusCreateRequest.cs" />
+    <Compile Include="Models\Request\BoxUserRolloutRequest.cs" />
     <Compile Include="Models\Request\BoxZipRequest.cs" />
     <Compile Include="Models\Request\BoxLegalHoldPolicyAssignmentRequest.cs" />
     <Compile Include="Models\Request\BoxLegalHoldPolicyRequest.cs" />

--- a/Box.V2/Models/Request/BoxUserRolloutRequest.cs
+++ b/Box.V2/Models/Request/BoxUserRolloutRequest.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 namespace Box.V2.Models
 {
     /// <summary>
-    /// A request class for rolling users out of box
+    /// A request class for rolling users out of the enterprise.
     /// </summary>
     public class BoxUserRollOutRequest : BoxUserRequest
     {

--- a/Box.V2/Models/Request/BoxUserRolloutRequest.cs
+++ b/Box.V2/Models/Request/BoxUserRolloutRequest.cs
@@ -1,0 +1,17 @@
+using Newtonsoft.Json;
+
+namespace Box.V2.Models
+{
+    /// <summary>
+    /// A request class for rolling users out of box
+    /// </summary>
+    public class BoxUserRollOutRequest : BoxUserRequest
+    {
+        /// <summary>
+        /// Setting this to null will roll the user out of the enterprise and make them a free user
+        /// </summary>
+        [JsonProperty(PropertyName = "enterprise", NullValueHandling = NullValueHandling.Include)]
+        public new string Enterprise { get; set; }
+
+    }
+}


### PR DESCRIPTION
Based on #709 