### PR TITLE
chore: run tests under all supported major netcore versions

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.1
       - name: Setup Nuget

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -27,14 +27,9 @@ jobs:
         run: msbuild .\Box.V2
       - name: Test
         run: dotnet test .\Box.V2.Test -f net45
-
-  core:
-    strategy:
-      matrix:
-        include:
-          - net-version: 2.0.0
-            net-runtime: netcoreapp2.0
-    name: Build and Test - Core
+  
+  core-build:
+    name: Build - Core
     runs-on: windows-latest
 
     steps:
@@ -43,8 +38,28 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '${{ matrix.net-version }}'
+          dotnet-version:
+            2.0.0
       - name: Build
         run: dotnet build .\Box.V2.Core
+
+  core-test:
+    name: Test - Core
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        version: [netcoreapp2.0, netcoreapp2.2, netcoreapp3.1, net5.0]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: | 
+            2.0.0
+            2.2.x
+            3.1.x
+            5.0.x
       - name: Test
         run: dotnet test .\Box.V2.Test -f ${{ matrix.net-runtime }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -29,6 +29,17 @@ jobs:
         run: dotnet test .\Box.V2.Test -f net45
 
   core:
+    strategy:
+      matrix:
+        include:
+          - net-version: 2.0.0
+            net-runtime: netcoreapp2.0
+          - net-version: 2.2.0
+            net-runtime: netcoreapp2.2
+          - net-version: 3.1.0
+            net-runtime: netcoreapp3.1
+          - net-version: 5.0.0
+            net-runtime: net5.0
     name: Build and Test - Core
     runs-on: windows-latest
 
@@ -38,8 +49,8 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '2.0.0'
+          dotnet-version: '${{ matrix.net-version }}'
       - name: Build
         run: dotnet build .\Box.V2.Core
       - name: Test
-        run: dotnet test .\Box.V2.Test -f netcoreapp2.0
+        run: dotnet test .\Box.V2.Test -f ${{ matrix.net-runtime }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -33,7 +33,7 @@ jobs:
         run: dotnet test .\Box.V2.Test -f net45
 
   core:
-    name: Build and test - Core
+    name: Build and Test - Core
     runs-on: windows-latest
 
     steps:

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,8 +34,6 @@ jobs:
         include:
           - net-version: 2.0.0
             net-runtime: netcoreapp2.0
-          - net-version: 2.2.x
-            net-runtime: netcoreapp2.2
           - net-version: 3.1.x
             net-runtime: netcoreapp3.1
           - net-version: 5.0.x

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -48,7 +48,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        version: [netcoreapp2.0, netcoreapp2.2, netcoreapp3.1, net5.0]
+        version: [netcoreapp2.0, netcoreapp2.2, netcoreapp3.1, net5.0, net6.0]
 
     steps:
       - name: Checkout
@@ -61,5 +61,6 @@ jobs:
             2.2.x
             3.1.x
             5.0.x
+            6.0.x
       - name: Test
         run: dotnet test .\Box.V2.Test -f ${{ matrix.version }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,28 +31,10 @@ jobs:
         run: msbuild .\Box.V2
       - name: Test
         run: dotnet test .\Box.V2.Test -f net45
-  
-  core-build:
-    name: Build - Core
-    runs-on: windows-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Setup dotnet
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version:
-            2.0.0
-      - name: Build
-        run: dotnet build .\Box.V2.Core
-
-  core-test:
-    name: Test - Core
+  core:
+    name: Build and test - Core
     runs-on: windows-latest
-    strategy:
-      matrix:
-        version: [netcoreapp2.0, netcoreapp2.2, netcoreapp3.1, net5.0, net6.0]
 
     steps:
       - name: Checkout
@@ -66,5 +48,15 @@ jobs:
             3.1.x
             5.0.x
             6.0.x
-      - name: Test
-        run: dotnet test .\Box.V2.Test -f ${{ matrix.version }}
+      - name: Build
+        run: dotnet build .\Box.V2.Core
+      - name: Test netcoreapp2.0
+        run: dotnet test .\Box.V2.Test -f netcoreapp2.0
+      - name: Test netcoreapp2.2
+        run: dotnet test .\Box.V2.Test -f netcoreapp2.2
+      - name: Test netcoreapp3.1
+        run: dotnet test .\Box.V2.Test -f netcoreapp3.1
+      - name: Test net5.0
+        run: dotnet test .\Box.V2.Test -f net5.0
+      - name: Test net6.0
+        run: dotnet test .\Box.V2.Test -f net6.0

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,11 +34,11 @@ jobs:
         include:
           - net-version: 2.0.0
             net-runtime: netcoreapp2.0
-          - net-version: 2.2.0
+          - net-version: 2.2.x
             net-runtime: netcoreapp2.2
-          - net-version: 3.1.0
+          - net-version: 3.1.x
             net-runtime: netcoreapp3.1
-          - net-version: 5.0.0
+          - net-version: 5.0.x
             net-runtime: net5.0
     name: Build and Test - Core
     runs-on: windows-latest

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -34,10 +34,6 @@ jobs:
         include:
           - net-version: 2.0.0
             net-runtime: netcoreapp2.0
-          - net-version: 3.1.x
-            net-runtime: netcoreapp3.1
-          - net-version: 5.0.x
-            net-runtime: net5.0
     name: Build and Test - Core
     runs-on: windows-latest
 

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -62,4 +62,4 @@ jobs:
             3.1.x
             5.0.x
       - name: Test
-        run: dotnet test .\Box.V2.Test -f ${{ matrix.net-runtime }}
+        run: dotnet test .\Box.V2.Test -f ${{ matrix.version }}

--- a/Box.V2.Test/Box.V2.Test.csproj
+++ b/Box.V2.Test/Box.V2.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.2;netcoreapp3.1;net5.0;net45</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -15,7 +15,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netcoreapp2.0'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netcore')) or $(TargetFramework.StartsWith('net5.0'))">
           <ProjectReference Include="..\Box.V2.Core\Box.V2.Core.csproj" />
       <PackageReference Include="Moq">
           <Version>4.7.0</Version>

--- a/Box.V2.Test/Box.V2.Test.csproj
+++ b/Box.V2.Test/Box.V2.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0;netcoreapp2.2;netcoreapp3.1;net5.0;net45</TargetFrameworks>

--- a/Box.V2.Test/Box.V2.Test.csproj
+++ b/Box.V2.Test/Box.V2.Test.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;netcoreapp2.2;netcoreapp3.1;net5.0;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;netcoreapp2.2;netcoreapp3.1;net5.0;net6.0;net45</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -15,7 +15,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework.StartsWith('netcore')) or $(TargetFramework.StartsWith('net5.0'))">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('netcore')) or $(TargetFramework.StartsWith('net5.0')) or $(TargetFramework.StartsWith('net6.0'))">
           <ProjectReference Include="..\Box.V2.Core\Box.V2.Core.csproj" />
       <PackageReference Include="Moq">
           <Version>4.7.0</Version>

--- a/Box.V2.Test/BoxFilesManagerTest.cs
+++ b/Box.V2.Test/BoxFilesManagerTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
@@ -805,7 +806,7 @@ namespace Box.V2.Test
             {
                 /*** Arrange ***/
                 var location = new Uri("http://dl.boxcloud.com");
-                HttpResponseHeaders headers = CreateInstanceNonPublicConstructor<HttpResponseHeaders>();
+                var headers = new HttpResponseMessage().Headers;
                 headers.Location = location;
                 Handler.Setup(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
                     .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
@@ -841,16 +842,12 @@ namespace Box.V2.Test
             using (var exampleFile = new FileStream(string.Format(GetSaveFolderPath(), "example.png"), FileMode.OpenOrCreate))
             {
                 /*** Arrange ***/
-                var location = new Uri("http://dl.boxcloud.com");
-                HttpResponseHeaders headers = CreateInstanceNonPublicConstructor<HttpResponseHeaders>();
-                headers.Location = location;
                 Handler.Setup(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
 
                     .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
                     {
                         Status = ResponseStatus.Success,
-                        Headers = headers
-
+ 
                     }));
                 IBoxRequest boxRequest = null;
                 Handler.Setup(h => h.ExecuteAsync<Stream>(It.IsAny<IBoxRequest>()))

--- a/Box.V2.Test/BoxFilesManagerTest.cs
+++ b/Box.V2.Test/BoxFilesManagerTest.cs
@@ -841,10 +841,10 @@ namespace Box.V2.Test
 
             using (var exampleFile = new FileStream(string.Format(GetSaveFolderPath(), "example.png"), FileMode.OpenOrCreate))
             {
+                /*** Arrange ***/
                 var location = new Uri("http://dl.boxcloud.com");
                 var headers = new HttpResponseMessage().Headers;
                 headers.Location = location;
-                /*** Arrange ***/
                 Handler.Setup(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
 
                     .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()

--- a/Box.V2.Test/BoxFilesManagerTest.cs
+++ b/Box.V2.Test/BoxFilesManagerTest.cs
@@ -841,13 +841,16 @@ namespace Box.V2.Test
 
             using (var exampleFile = new FileStream(string.Format(GetSaveFolderPath(), "example.png"), FileMode.OpenOrCreate))
             {
+                var location = new Uri("http://dl.boxcloud.com");
+                var headers = new HttpResponseMessage().Headers;
+                headers.Location = location;
                 /*** Arrange ***/
                 Handler.Setup(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
 
                     .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
                     {
                         Status = ResponseStatus.Success,
- 
+                        Headers = headers
                     }));
                 IBoxRequest boxRequest = null;
                 Handler.Setup(h => h.ExecuteAsync<Stream>(It.IsAny<IBoxRequest>()))

--- a/Box.V2.Test/BoxFoldersManagerTest.cs
+++ b/Box.V2.Test/BoxFoldersManagerTest.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http.Headers;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Box.V2.Config;
 using Box.V2.Exceptions;
@@ -201,7 +201,7 @@ namespace Box.V2.Test
         [TestMethod]
         public async Task CreateFolder_ValidResponse_BadRequest()
         {
-            HttpResponseHeaders headers = CreateInstanceNonPublicConstructor<HttpResponseHeaders>();
+            var headers = new HttpResponseMessage().Headers;
             headers.Add("BOX-REQUEST-ID", "0vsm9dam264cpub3esr293i4ssm");
             Handler.Setup(h => h.ExecuteAsync<BoxFolder>(It.IsAny<IBoxRequest>()))
                 .Returns(() => Task.FromResult<IBoxResponse<BoxFolder>>(new BoxResponse<BoxFolder>()
@@ -237,10 +237,9 @@ namespace Box.V2.Test
             }
         }
 
-        [TestMethod]
         public async Task CreateFolder_Unauthorized()
         {
-            HttpResponseHeaders headers = CreateInstanceNonPublicConstructor<HttpResponseHeaders>();
+            var headers = new HttpResponseMessage().Headers;
             headers.Add("BOX-REQUEST-ID", "0vsm9dam264cpub3esr293i4ssm");
             Handler.Setup(h => h.ExecuteAsync<BoxFolder>(It.IsAny<IBoxRequest>()))
                 .Returns(() => Task.FromResult<IBoxResponse<BoxFolder>>(new BoxResponse<BoxFolder>()

--- a/Box.V2.Test/BoxJWTAuthTest.cs
+++ b/Box.V2.Test/BoxJWTAuthTest.cs
@@ -6,6 +6,7 @@ using Box.V2.Exceptions;
 using Box.V2.JWTAuth;
 using Box.V2.Request;
 using Box.V2.Services;
+using Box.V2.Test.Helpers;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 
@@ -27,7 +28,7 @@ namespace Box.V2.Test
             _boxConfig = new Mock<IBoxConfig>();
             _boxConfig.SetupGet(x => x.EnterpriseId).Returns("12345");
             _boxConfig.SetupGet(x => x.BoxApiHostUri).Returns(new Uri(Constants.BoxApiHostUriString));
-            _jwtAuth = new BoxJWTAuth(_boxConfig.Object, _service);
+            _jwtAuth = new BoxJWTAuth(_boxConfig.Object, _service, new InstantRetryStrategy());
         }
 
         [TestMethod]

--- a/Box.V2.Test/BoxResourceManagerTest.cs
+++ b/Box.V2.Test/BoxResourceManagerTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.IO;
-using System.Reflection;
 using System.Text;
 using Box.V2.Auth;
 using Box.V2.Config;
@@ -71,21 +70,6 @@ namespace Box.V2.Test
                 sb.Append(hex);
             }
             return sb.ToString();
-        }
-        public static T CreateInstanceNonPublicConstructor<T>()
-        {
-            _ = new Type[0];
-
-            ConstructorInfo[] c = typeof(T).GetConstructors
-                (BindingFlags.NonPublic | BindingFlags.Instance
-                );
-
-            var inst =
-                (T)c[0].Invoke(BindingFlags.NonPublic,
-                               null,
-                               null,
-                               System.Threading.Thread.CurrentThread.CurrentCulture);
-            return inst;
         }
 
         public string LoadFixtureFromJson(string path)

--- a/Box.V2.Test/Helpers/InstantRetryStrategy.cs
+++ b/Box.V2.Test/Helpers/InstantRetryStrategy.cs
@@ -1,0 +1,13 @@
+using System;
+using Box.V2.Utility;
+
+namespace Box.V2.Test.Helpers
+{
+    public class InstantRetryStrategy : IRetryStrategy
+    {
+        TimeSpan IRetryStrategy.GetRetryTimeout(int numRetries)
+        {
+            return TimeSpan.Zero;
+        }
+    }
+}

--- a/Box.V2.Test/RetryStrategyTest.cs
+++ b/Box.V2.Test/RetryStrategyTest.cs
@@ -1,0 +1,36 @@
+using System;
+using Box.V2.Utility;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Box.V2.Test
+{
+    [TestClass]
+    public class RetryStrategyTest : BoxResourceManagerTest
+    {
+        [TestMethod]
+        public void ExponentialBackoff_ForDifferentRetryNumber_ReturnCorrectRetryTime()
+        {
+            var exponentialBackoff = new ExponentialBackoff();
+
+            var firstRetry = exponentialBackoff.GetRetryTimeout(1);
+            Assert.IsTrue(firstRetry <= TimeSpan.FromSeconds(3));
+            Assert.IsTrue(firstRetry >= TimeSpan.FromSeconds(1));
+
+            var secondRetry = exponentialBackoff.GetRetryTimeout(2);
+            Assert.IsTrue(secondRetry <= TimeSpan.FromSeconds(6));
+            Assert.IsTrue(secondRetry >= TimeSpan.FromSeconds(2));
+
+            var thirdRetry = exponentialBackoff.GetRetryTimeout(3);
+            Assert.IsTrue(thirdRetry <= TimeSpan.FromSeconds(12));
+            Assert.IsTrue(thirdRetry >= TimeSpan.FromSeconds(4));
+
+            var fourthRetry = exponentialBackoff.GetRetryTimeout(4);
+            Assert.IsTrue(fourthRetry <= TimeSpan.FromSeconds(24));
+            Assert.IsTrue(fourthRetry >= TimeSpan.FromSeconds(8));
+
+            var fifthRetry = exponentialBackoff.GetRetryTimeout(5);
+            Assert.IsTrue(fifthRetry <= TimeSpan.FromSeconds(48));
+            Assert.IsTrue(fifthRetry >= TimeSpan.FromSeconds(16));
+        }
+    }
+}

--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -260,6 +260,7 @@
     <Compile Include="Utility\CrossPlatform.cs" />
     <Compile Include="Utility\ExponentialBackoff.cs" />
     <Compile Include="Utility\Helper.cs" />
+    <Compile Include="Utility\IRetryStrategy.cs" />
     <Compile Include="Utility\LRUCache.cs" />
     <Compile Include="Utility\Retry.cs" />
     <Compile Include="Wrappers\BoxError.cs" />

--- a/Box.V2/Utility/ExponentialBackoff.cs
+++ b/Box.V2/Utility/ExponentialBackoff.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Box.V2.Utility
 {
-    public class ExponentialBackoff
+    public class ExponentialBackoff : IRetryStrategy
     {
         public TimeSpan GetRetryTimeout(int numRetries)
         {

--- a/Box.V2/Utility/IRetryStrategy.cs
+++ b/Box.V2/Utility/IRetryStrategy.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace Box.V2.Utility
+{
+    /// <summary>
+    /// Retry strategy used when retrying HTTP request.
+    /// </summary>
+    public interface IRetryStrategy
+    {
+        /// <summary>
+        /// Returns the time interval after which to retry the request.
+        /// </summary>
+        /// <param name="numRetries">Retry number</param>
+        /// <returns>Retry interval</returns>
+        TimeSpan GetRetryTimeout(int numRetries);
+    }
+}


### PR DESCRIPTION
I also refactored exponential backoff test to speed it up considerably.
Tests in core against different runtimes are in a single job, as this is faster than multiple ones.