### PR TITLE
feat: add `can_edit` field to `SharedLink`

### DIFF
--- a/Box.V2.Test.Integration/BoxFilesManagerIntegrationTest.cs
+++ b/Box.V2.Test.Integration/BoxFilesManagerIntegrationTest.cs
@@ -266,6 +266,30 @@ namespace Box.V2.Test.Integration
             Assert.AreEqual("2", response.Entries[0].VersionNumber);
         }
 
+        [TestMethod]
+        public async Task AddSharedLink_ForValidNewFile_ShouldCreateNewSharedLink()
+        {
+            var file = await CreateSmallFile();
+
+            var sharedLinkRequest = new BoxSharedLinkRequest()
+            {
+                VanityName = GetShortUniqueName("SharedLink"),
+                Access = BoxSharedLinkAccessType.open,
+                Permissions = new BoxPermissionsRequest
+                {
+                    Download = true,
+                    Edit = true,
+                }
+            };
+
+            var response = await UserClient.FilesManager.CreateSharedLinkAsync(file.Id, sharedLinkRequest);
+
+            Assert.AreEqual(file.Id, response.Id);
+            Assert.AreEqual(BoxSharedLinkAccessType.open, response.SharedLink.Access);
+            Assert.IsTrue(response.SharedLink.Permissions.CanDownload);
+            Assert.IsTrue(response.SharedLink.Permissions.CanEdit);
+        }
+
         private int GetNumberOfParts(long totalSize, long partSize)
         {
             if (partSize == 0)

--- a/Box.V2.Test.Integration/BoxWebLinkManagerIntegrationTest.cs
+++ b/Box.V2.Test.Integration/BoxWebLinkManagerIntegrationTest.cs
@@ -62,5 +62,21 @@ namespace Box.V2.Test.Integration
 
             await Assert.ThrowsExceptionAsync<BoxAPIException>(async () => { _ = await UserClient.WebLinksManager.GetWebLinkAsync(weblink.Id); });
         }
+
+        [TestMethod]
+        public async Task AddSharedLink_ForNewWeblink_ShouldCreateNewSharedLink()
+        {
+            var webLink = await CreateWebLink(GetUniqueName("weblink"), FolderId);
+
+            var sharedLinkReq = new BoxSharedLinkRequest()
+            {
+                Access = BoxSharedLinkAccessType.open
+            };
+
+            var response = await UserClient.WebLinksManager.CreateSharedLinkAsync(webLink.Id, sharedLinkReq);
+
+            Assert.AreEqual(webLink.Id, response.Id);
+            Assert.AreEqual(BoxSharedLinkAccessType.open, response.SharedLink.Access);
+        }
     }
 }

--- a/Box.V2.Test.Integration/Configuration/IntegrationTestBase.cs
+++ b/Box.V2.Test.Integration/Configuration/IntegrationTestBase.cs
@@ -149,6 +149,11 @@ namespace Box.V2.Test.Integration
             return uniqueName;
         }
 
+        protected static string GetShortUniqueName(string resourceName)
+        {
+            return GetUniqueName(resourceName, false).Substring(0, 20);
+        }
+
         public static async Task ExecuteCommand(ICleanupCommand command)
         {
             IBoxClient client = GetClient(command);

--- a/Box.V2.Test/Box.V2.Test.csproj
+++ b/Box.V2.Test/Box.V2.Test.csproj
@@ -47,10 +47,16 @@
     <None Update="Fixtures\BoxFileRequest\GetFileRequest200.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\BoxFiles\CreateFileSharedLink200.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Fixtures\BoxFiles\ViewVersions200.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Fixtures\BoxFiles\UploadNewVersionUsingSession200.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\BoxFolders\CreateFolderSharedLink200.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Fixtures\BoxMetadata\ExecuteMetadataQuery200.json">
@@ -72,6 +78,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="Fixtures\BoxUsers\AddOrUpdateUserAvatar200.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\BoxWebLinks\CreateWebLinkSharedLink200.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="TestData\smalltest.pdf">

--- a/Box.V2.Test/BoxFilesManagerTest.cs
+++ b/Box.V2.Test/BoxFilesManagerTest.cs
@@ -412,12 +412,11 @@ namespace Box.V2.Test
         public async Task CreateFileSharedLink_ValidResponse_ValidFile()
         {
             /*** Arrange ***/
-            var responseString = "{ \"type\": \"file\", \"id\": \"5000948880\", \"sequence_id\": \"3\", \"etag\": \"3\", \"sha1\": \"134b65991ed521fcfe4724b7d814ab8ded5185dc\", \"name\": \"tigers.jpeg\", \"description\": \"a picture of tigers\", \"size\": 629644, \"path_collection\": { \"total_count\": 2, \"entries\": [ { \"type\": \"folder\", \"id\": \"0\", \"sequence_id\": null, \"etag\": null, \"name\": \"All Files\" }, { \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\" } ] }, \"created_at\": \"2012-12-12T10:55:30-08:00\", \"modified_at\": \"2012-12-12T11:04:26-08:00\", \"created_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"modified_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"owned_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"shared_link\": { \"url\": \"https://www.box.com/s/rh935iit6ewrmw0unyul\", \"download_url\": \"https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg\", \"vanity_url\": null, \"vanity_name\": \"my-custom-vanity-name\", \"is_password_enabled\": false, \"unshared_at\": null, \"download_count\": 0, \"preview_count\": 0, \"access\": \"open\", \"permissions\": { \"can_download\": true, \"can_preview\": true } }, \"parent\": { \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\" }, \"item_status\": \"active\" }";
             Handler.Setup(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
                 .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
                 {
                     Status = ResponseStatus.Success,
-                    ContentString = responseString
+                    ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/CreateFileSharedLink200.json")
                 }));
 
             var sharedLink = new BoxSharedLinkRequest()
@@ -440,6 +439,7 @@ namespace Box.V2.Test
             Assert.AreEqual("user", f.CreatedBy.Type);
             Assert.AreEqual("17738362", f.CreatedBy.Id);
             Assert.AreEqual("my-custom-vanity-name", f.SharedLink.VanityName);
+            Assert.AreEqual(true, f.SharedLink.Permissions.CanEdit);
         }
 
         [TestMethod]

--- a/Box.V2.Test/BoxFoldersManagerTest.cs
+++ b/Box.V2.Test/BoxFoldersManagerTest.cs
@@ -609,7 +609,7 @@ namespace Box.V2.Test
         }
 
         [TestMethod]
-        public async Task CreateFolderSharedLink_ShouldSendEditFalse_EvenIfEditIsSetToTrue()
+        public async Task CreateFolderSharedLink_ShouldThrowArgumentException_WhenEditIsFalse()
         {
             /*** Arrange ***/
             IBoxRequest boxRequest = null;
@@ -631,11 +631,8 @@ namespace Box.V2.Test
                 }
             };
 
-            /*** Act ***/
-            BoxFolder w = await _foldersManager.CreateSharedLinkAsync("12345", sharedLink);
-
-            /*** Assert ***/
-            Assert.AreEqual("{\"shared_link\":{\"access\":\"collaborators\",\"permissions\":{\"can_download\":false,\"can_edit\":false},\"vanity_name\":\"my-custom-vanity-name\"}}", boxRequest.Payload);
+            /*** Act && Assert ***/
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () => { _ = await _foldersManager.CreateSharedLinkAsync("12345", sharedLink); });
         }
 
         [TestMethod]

--- a/Box.V2.Test/BoxFoldersManagerTest.cs
+++ b/Box.V2.Test/BoxFoldersManagerTest.cs
@@ -586,7 +586,7 @@ namespace Box.V2.Test
                 .Returns(() => Task.FromResult<IBoxResponse<BoxFolder>>(new BoxResponse<BoxFolder>()
                 {
                     Status = ResponseStatus.Success,
-                    ContentString = "{ \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\", \"created_at\": \"2012-12-12T10:53:43-08:00\", \"modified_at\": \"2012-12-12T11:15:04-08:00\", \"description\": \"Some pictures I took\", \"size\": 629644, \"path_collection\": { \"total_count\": 1, \"entries\": [ { \"type\": \"folder\", \"id\": \"0\", \"sequence_id\": null, \"etag\": null, \"name\": \"All Files\" } ] }, \"created_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"modified_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"owned_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"shared_link\": { \"url\": \"https://www.box.com/s/vspke7y05sb214wjokpk\", \"download_url\": \"https://www.box.com/shared/static/vspke7y05sb214wjokpk\", \"vanity_url\": null, \"vanity_name\": \"my-custom-vanity-name\", \"is_password_enabled\": false, \"unshared_at\": null, \"download_count\": 0, \"preview_count\": 0, \"access\": \"open\", \"permissions\": { \"can_download\": true, \"can_preview\": true } }, \"folder_upload_email\": { \"access\": \"open\", \"email\": \"upload.Picture.k13sdz1@u.box.com\" }, \"parent\": { \"type\": \"folder\", \"id\": \"0\", \"sequence_id\": null, \"etag\": null, \"name\": \"All Files\" }, \"item_status\": \"active\", \"item_collection\": { \"total_count\": 1, \"entries\": [ { \"type\": \"file\", \"id\": \"5000948880\", \"sequence_id\": \"3\", \"etag\": \"3\", \"sha1\": \"134b65991ed521fcfe4724b7d814ab8ded5185dc\", \"name\": \"tigers.jpeg\" } ], \"offset\": 0, \"limit\": 100 } }"
+                    ContentString = LoadFixtureFromJson("Fixtures/BoxFolders/CreateFolderSharedLink200.json")
                 }));
 
             /*** Act ***/
@@ -605,6 +605,37 @@ namespace Box.V2.Test
             Assert.AreEqual("1", f.ETag);
             Assert.AreEqual("Pictures", f.Name);
             Assert.AreEqual("my-custom-vanity-name", f.SharedLink.VanityName);
+            Assert.AreEqual(false, f.SharedLink.Permissions.CanEdit);
+        }
+
+        [TestMethod]
+        public async Task CreateFolderSharedLink_ShouldSendEditFalse_EvenIfEditIsSetToTrue()
+        {
+            /*** Arrange ***/
+            IBoxRequest boxRequest = null;
+            Handler.Setup(h => h.ExecuteAsync<BoxFolder>(It.IsAny<IBoxRequest>()))
+                .Returns(() => Task.FromResult<IBoxResponse<BoxFolder>>(new BoxResponse<BoxFolder>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = LoadFixtureFromJson("Fixtures/BoxFolders/CreateFolderSharedLink200.json")
+                }))
+                .Callback<IBoxRequest>(r => boxRequest = r);
+
+            var sharedLink = new BoxSharedLinkRequest()
+            {
+                Access = BoxSharedLinkAccessType.collaborators,
+                VanityName = "my-custom-vanity-name",
+                Permissions = new BoxPermissionsRequest
+                {
+                    Edit = true
+                }
+            };
+
+            /*** Act ***/
+            BoxFolder w = await _foldersManager.CreateSharedLinkAsync("12345", sharedLink);
+
+            /*** Assert ***/
+            Assert.AreEqual("{\"shared_link\":{\"access\":\"collaborators\",\"permissions\":{\"can_download\":false,\"can_edit\":false},\"vanity_name\":\"my-custom-vanity-name\"}}", boxRequest.Payload);
         }
 
         [TestMethod]

--- a/Box.V2.Test/BoxFoldersManagerTest.cs
+++ b/Box.V2.Test/BoxFoldersManagerTest.cs
@@ -609,7 +609,7 @@ namespace Box.V2.Test
         }
 
         [TestMethod]
-        public async Task CreateFolderSharedLink_ShouldThrowArgumentException_WhenEditIsFalse()
+        public async Task CreateFolderSharedLink_ShouldThrowArgumentException_WhenEditIsTrue()
         {
             /*** Arrange ***/
             IBoxRequest boxRequest = null;

--- a/Box.V2.Test/BoxWebLinksManagerTest.cs
+++ b/Box.V2.Test/BoxWebLinksManagerTest.cs
@@ -490,7 +490,7 @@ namespace Box.V2.Test
         }
 
         [TestMethod]
-        public async Task CreateWebLinkSharedLink_ShouldThrowArgumentException_WhenEditIsFalse()
+        public async Task CreateWebLinkSharedLink_ShouldThrowArgumentException_WhenEditIsTrue()
         {
             /*** Arrange ***/
             IBoxRequest boxRequest = null;

--- a/Box.V2.Test/BoxWebLinksManagerTest.cs
+++ b/Box.V2.Test/BoxWebLinksManagerTest.cs
@@ -490,7 +490,7 @@ namespace Box.V2.Test
         }
 
         [TestMethod]
-        public async Task CreateWebLinkSharedLink_ShouldSendEditFalse_EvenIfEditIsSetToTrue()
+        public async Task CreateWebLinkSharedLink_ShouldThrowArgumentException_WhenEditIsFalse()
         {
             /*** Arrange ***/
             IBoxRequest boxRequest = null;
@@ -512,11 +512,8 @@ namespace Box.V2.Test
                 }
             };
 
-            /*** Act ***/
-            BoxWebLink w = await _webLinkManager.CreateSharedLinkAsync("12345", sharedLink);
-
-            /*** Assert ***/
-            Assert.AreEqual("{\"shared_link\":{\"access\":\"collaborators\",\"permissions\":{\"can_download\":false,\"can_edit\":false},\"vanity_name\":\"my-custom-vanity-name\"}}", boxRequest.Payload);
+            /*** Act && Assert ***/
+            await Assert.ThrowsExceptionAsync<ArgumentException>(async () => { _ = await _webLinkManager.CreateSharedLinkAsync("12345", sharedLink); });
         }
 
         [TestMethod]

--- a/Box.V2.Test/BoxWebLinksManagerTest.cs
+++ b/Box.V2.Test/BoxWebLinksManagerTest.cs
@@ -457,7 +457,6 @@ namespace Box.V2.Test
         public async Task CreateWebLinkSharedLink_ValidResponse_ValidFile()
         {
             /*** Arrange ***/
-            var responseString = "{ \"type\": \"web_link\", \"id\": \"5000948880\", \"sequence_id\": \"3\", \"etag\": \"3\", \"sha1\": \"134b65991ed521fcfe4724b7d814ab8ded5185dc\", \"name\": \"tigers.jpeg\", \"description\": \"a picture of tigers\", \"size\": 629644, \"path_collection\": { \"total_count\": 2, \"entries\": [ { \"type\": \"folder\", \"id\": \"0\", \"sequence_id\": null, \"etag\": null, \"name\": \"All Files\" }, { \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\" } ] }, \"created_at\": \"2012-12-12T10:55:30-08:00\", \"modified_at\": \"2012-12-12T11:04:26-08:00\", \"created_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"modified_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"owned_by\": { \"type\": \"user\", \"id\": \"17738362\", \"name\": \"sean rose\", \"login\": \"sean@box.com\" }, \"shared_link\": { \"url\": \"https://www.box.com/s/rh935iit6ewrmw0unyul\",  \"vanity_name\": \"my-custom-vanity-name\", \"download_url\": \"https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg\", \"vanity_url\": null, \"is_password_enabled\": false, \"unshared_at\": null, \"download_count\": 0, \"preview_count\": 0, \"access\": \"open\", \"permissions\": { \"can_download\": true, \"can_preview\": true } }, \"parent\": { \"type\": \"folder\", \"id\": \"11446498\", \"sequence_id\": \"1\", \"etag\": \"1\", \"name\": \"Pictures\" }, \"item_status\": \"active\" }";
             IBoxRequest boxRequest = null;
             var webLinksUri = new Uri(Constants.WebLinksEndpointString);
             Config.SetupGet(x => x.WebLinksEndpointUri).Returns(webLinksUri);
@@ -465,14 +464,14 @@ namespace Box.V2.Test
                 .Returns(Task.FromResult<IBoxResponse<BoxWebLink>>(new BoxResponse<BoxWebLink>()
                 {
                     Status = ResponseStatus.Success,
-                    ContentString = responseString
+                    ContentString = LoadFixtureFromJson("Fixtures/BoxWebLinks/CreateWebLinkSharedLink200.json")
                 }))
                 .Callback<IBoxRequest>(r => boxRequest = r);
 
             var sharedLink = new BoxSharedLinkRequest()
             {
                 Access = BoxSharedLinkAccessType.collaborators,
-                VanityName = "my-custom-vanity-name"
+                VanityName = "my-custom-vanity-name",
             };
 
             /*** Act ***/
@@ -488,6 +487,36 @@ namespace Box.V2.Test
             Assert.AreEqual("3", w.ETag);
             Assert.AreEqual("https://www.box.com/s/rh935iit6ewrmw0unyul", w.SharedLink.Url);
             Assert.AreEqual("my-custom-vanity-name", w.SharedLink.VanityName);
+        }
+
+        [TestMethod]
+        public async Task CreateWebLinkSharedLink_ShouldSendEditFalse_EvenIfEditIsSetToTrue()
+        {
+            /*** Arrange ***/
+            IBoxRequest boxRequest = null;
+            Handler.Setup(h => h.ExecuteAsync<BoxWebLink>(It.IsAny<IBoxRequest>()))
+                .Returns(Task.FromResult<IBoxResponse<BoxWebLink>>(new BoxResponse<BoxWebLink>()
+                {
+                    Status = ResponseStatus.Success,
+                    ContentString = LoadFixtureFromJson("Fixtures/BoxWebLinks/CreateWebLinkSharedLink200.json")
+                }))
+                .Callback<IBoxRequest>(r => boxRequest = r);
+
+            var sharedLink = new BoxSharedLinkRequest()
+            {
+                Access = BoxSharedLinkAccessType.collaborators,
+                VanityName = "my-custom-vanity-name",
+                Permissions = new BoxPermissionsRequest
+                {
+                    Edit = true
+                }
+            };
+
+            /*** Act ***/
+            BoxWebLink w = await _webLinkManager.CreateSharedLinkAsync("12345", sharedLink);
+
+            /*** Assert ***/
+            Assert.AreEqual("{\"shared_link\":{\"access\":\"collaborators\",\"permissions\":{\"can_download\":false,\"can_edit\":false},\"vanity_name\":\"my-custom-vanity-name\"}}", boxRequest.Payload);
         }
 
         [TestMethod]

--- a/Box.V2.Test/Fixtures/BoxFiles/CreateFileSharedLink200.json
+++ b/Box.V2.Test/Fixtures/BoxFiles/CreateFileSharedLink200.json
@@ -1,0 +1,73 @@
+{
+  "type": "file",
+  "id": "5000948880",
+  "sequence_id": "3",
+  "etag": "3",
+  "sha1": "134b65991ed521fcfe4724b7d814ab8ded5185dc",
+  "name": "tigers.jpeg",
+  "description": "a picture of tigers",
+  "size": 629644,
+  "path_collection": {
+    "total_count": 2,
+    "entries": [
+      {
+        "type": "folder",
+        "id": "0",
+        "sequence_id": null,
+        "etag": null,
+        "name": "All Files"
+      },
+      {
+        "type": "folder",
+        "id": "11446498",
+        "sequence_id": "1",
+        "etag": "1",
+        "name": "Pictures"
+      }
+    ]
+  },
+  "created_at": "2012-12-12T10:55:30-08:00",
+  "modified_at": "2012-12-12T11:04:26-08:00",
+  "created_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "modified_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "owned_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "shared_link": {
+    "url": "https://www.box.com/s/rh935iit6ewrmw0unyul",
+    "download_url": "https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
+    "vanity_url": null,
+    "vanity_name": "my-custom-vanity-name",
+    "is_password_enabled": false,
+    "unshared_at": null,
+    "download_count": 0,
+    "preview_count": 0,
+    "access": "open",
+    "permissions": {
+      "can_download": true,
+      "can_preview": true,
+      "can_edit": true
+    }
+  },
+  "parent": {
+    "type": "folder",
+    "id": "11446498",
+    "sequence_id": "1",
+    "etag": "1",
+    "name": "Pictures"
+  },
+  "item_status": "active"
+}

--- a/Box.V2.Test/Fixtures/BoxFolders/CreateFolderSharedLink200.json
+++ b/Box.V2.Test/Fixtures/BoxFolders/CreateFolderSharedLink200.json
@@ -1,0 +1,84 @@
+{
+  "type": "folder",
+  "id": "11446498",
+  "sequence_id": "1",
+  "etag": "1",
+  "name": "Pictures",
+  "created_at": "2012-12-12T10:53:43-08:00",
+  "modified_at": "2012-12-12T11:15:04-08:00",
+  "description": "Some pictures I took",
+  "size": 629644,
+  "path_collection": {
+    "total_count": 1,
+    "entries": [
+      {
+        "type": "folder",
+        "id": "0",
+        "sequence_id": null,
+        "etag": null,
+        "name": "All Files"
+      }
+    ]
+  },
+  "created_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "modified_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "owned_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "shared_link": {
+    "url": "https://www.box.com/s/vspke7y05sb214wjokpk",
+    "download_url": "https://www.box.com/shared/static/vspke7y05sb214wjokpk",
+    "vanity_url": null,
+    "vanity_name": "my-custom-vanity-name",
+    "is_password_enabled": false,
+    "unshared_at": null,
+    "download_count": 0,
+    "preview_count": 0,
+    "access": "open",
+    "permissions": {
+      "can_download": true,
+      "can_preview": true,
+      "can_edit" : false
+    }
+  },
+  "folder_upload_email": {
+    "access": "open",
+    "email": "upload.Picture.k13sdz1@u.box.com"
+  },
+  "parent": {
+    "type": "folder",
+    "id": "0",
+    "sequence_id": null,
+    "etag": null,
+    "name": "All Files"
+  },
+  "item_status": "active",
+  "item_collection": {
+    "total_count": 1,
+    "entries": [
+      {
+        "type": "file",
+        "id": "5000948880",
+        "sequence_id": "3",
+        "etag": "3",
+        "sha1": "134b65991ed521fcfe4724b7d814ab8ded5185dc",
+        "name": "tigers.jpeg"
+      }
+    ],
+    "offset": 0,
+    "limit": 100
+  }
+}

--- a/Box.V2.Test/Fixtures/BoxWebLinks/CreateWebLinkSharedLink200.json
+++ b/Box.V2.Test/Fixtures/BoxWebLinks/CreateWebLinkSharedLink200.json
@@ -1,0 +1,73 @@
+{
+  "type": "web_link",
+  "id": "5000948880",
+  "sequence_id": "3",
+  "etag": "3",
+  "sha1": "134b65991ed521fcfe4724b7d814ab8ded5185dc",
+  "name": "tigers.jpeg",
+  "description": "a picture of tigers",
+  "size": 629644,
+  "path_collection": {
+    "total_count": 2,
+    "entries": [
+      {
+        "type": "folder",
+        "id": "0",
+        "sequence_id": null,
+        "etag": null,
+        "name": "All Files"
+      },
+      {
+        "type": "folder",
+        "id": "11446498",
+        "sequence_id": "1",
+        "etag": "1",
+        "name": "Pictures"
+      }
+    ]
+  },
+  "created_at": "2012-12-12T10:55:30-08:00",
+  "modified_at": "2012-12-12T11:04:26-08:00",
+  "created_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "modified_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "owned_by": {
+    "type": "user",
+    "id": "17738362",
+    "name": "sean rose",
+    "login": "sean@box.com"
+  },
+  "shared_link": {
+    "url": "https://www.box.com/s/rh935iit6ewrmw0unyul",
+    "vanity_name": "my-custom-vanity-name",
+    "download_url": "https://www.box.com/shared/static/rh935iit6ewrmw0unyul.jpeg",
+    "vanity_url": null,
+    "is_password_enabled": false,
+    "unshared_at": null,
+    "download_count": 0,
+    "preview_count": 0,
+    "access": "open",
+    "permissions": {
+      "can_download": true,
+      "can_preview": true,
+      "can_edit": false
+    }
+  },
+  "parent": {
+    "type": "folder",
+    "id": "11446498",
+    "sequence_id": "1",
+    "etag": "1",
+    "name": "Pictures"
+  },
+  "item_status": "active"
+}

--- a/Box.V2/Extensions/BoxExtensions.cs
+++ b/Box.V2/Extensions/BoxExtensions.cs
@@ -46,7 +46,7 @@ namespace Box.V2.Extensions
         /// <returns></returns>
         internal static T ThrowIfDifferent<T>(this T value, string name, T expectedValue)
         {
-            return !value.Equals(expectedValue) ? throw new ArgumentException($"Required field must equal to {expectedValue}", name) : value;
+            return value != null && !value.Equals(expectedValue) ? throw new ArgumentException($"Field should equal to {expectedValue} or null", name) : value;
         }
     }
 }

--- a/Box.V2/Extensions/BoxExtensions.cs
+++ b/Box.V2/Extensions/BoxExtensions.cs
@@ -36,5 +36,17 @@ namespace Box.V2.Extensions
         {
             return string.IsNullOrWhiteSpace(value) ? throw new ArgumentException("Required field cannot be null or whitespace", name) : value;
         }
+
+        /// <summary>
+        /// Checks if a value is equal to the expectedValue
+        /// </summary>
+        /// <param name="value"></param>
+        /// <param name="name"></param>
+        /// <param name="expectedValue"></param>
+        /// <returns></returns>
+        internal static T ThrowIfDifferent<T>(this T value, string name, T expectedValue)
+        {
+            return !value.Equals(expectedValue) ? throw new ArgumentException($"Required field must equal to {expectedValue}", name) : value;
+        }
     }
 }

--- a/Box.V2/Managers/BoxFoldersManager.cs
+++ b/Box.V2/Managers/BoxFoldersManager.cs
@@ -208,7 +208,7 @@ namespace Box.V2.Managers
             id.ThrowIfNullOrWhiteSpace("id");
 
             if (sharedLinkRequest.Permissions != null)
-                sharedLinkRequest.Permissions.Edit.ThrowIfDifferent("sharedLinkRequest.permissions.can_edit", false);
+                sharedLinkRequest.Permissions.Edit.ThrowIfDifferent("sharedLinkRequest.permissions.edit", false);
 
             BoxRequest request = new BoxRequest(_config.FoldersEndpointUri, id)
                 .Method(RequestMethod.Put)

--- a/Box.V2/Managers/BoxFoldersManager.cs
+++ b/Box.V2/Managers/BoxFoldersManager.cs
@@ -207,7 +207,8 @@ namespace Box.V2.Managers
         {
             id.ThrowIfNullOrWhiteSpace("id");
 
-            sharedLinkRequest.EnsureEditIsFalse();
+            if (sharedLinkRequest.Permissions != null)
+                sharedLinkRequest.Permissions.Edit.ThrowIfDifferent("sharedLinkRequest.permissions.can_edit", false);
 
             BoxRequest request = new BoxRequest(_config.FoldersEndpointUri, id)
                 .Method(RequestMethod.Put)

--- a/Box.V2/Managers/BoxFoldersManager.cs
+++ b/Box.V2/Managers/BoxFoldersManager.cs
@@ -207,6 +207,8 @@ namespace Box.V2.Managers
         {
             id.ThrowIfNullOrWhiteSpace("id");
 
+            sharedLinkRequest.EnsureEditIsFalse();
+
             BoxRequest request = new BoxRequest(_config.FoldersEndpointUri, id)
                 .Method(RequestMethod.Put)
                 .Param(ParamFields, fields)

--- a/Box.V2/Managers/BoxFoldersManager.cs
+++ b/Box.V2/Managers/BoxFoldersManager.cs
@@ -207,7 +207,7 @@ namespace Box.V2.Managers
         {
             id.ThrowIfNullOrWhiteSpace("id");
 
-            if (sharedLinkRequest.Permissions != null)
+            if (sharedLinkRequest?.Permissions != null)
                 sharedLinkRequest.Permissions.Edit.ThrowIfDifferent("sharedLinkRequest.permissions.edit", false);
 
             BoxRequest request = new BoxRequest(_config.FoldersEndpointUri, id)

--- a/Box.V2/Managers/BoxWebLinksManager.cs
+++ b/Box.V2/Managers/BoxWebLinksManager.cs
@@ -131,7 +131,7 @@ namespace Box.V2.Managers
             sharedLinkRequest.ThrowIfNull("sharedLinkRequest");
 
             if (sharedLinkRequest.Permissions != null)
-                sharedLinkRequest.Permissions.Edit.ThrowIfDifferent("sharedLinkRequest.permissions.can_edit", false);
+                sharedLinkRequest.Permissions.Edit.ThrowIfDifferent("sharedLinkRequest.permissions.edit", false);
 
             BoxRequest request = new BoxRequest(_config.WebLinksEndpointUri, id)
                 .Method(RequestMethod.Put)

--- a/Box.V2/Managers/BoxWebLinksManager.cs
+++ b/Box.V2/Managers/BoxWebLinksManager.cs
@@ -130,7 +130,7 @@ namespace Box.V2.Managers
             id.ThrowIfNullOrWhiteSpace("id");
             sharedLinkRequest.ThrowIfNull("sharedLinkRequest");
 
-            if (sharedLinkRequest.Permissions != null)
+            if (sharedLinkRequest?.Permissions != null)
                 sharedLinkRequest.Permissions.Edit.ThrowIfDifferent("sharedLinkRequest.permissions.edit", false);
 
             BoxRequest request = new BoxRequest(_config.WebLinksEndpointUri, id)

--- a/Box.V2/Managers/BoxWebLinksManager.cs
+++ b/Box.V2/Managers/BoxWebLinksManager.cs
@@ -130,6 +130,8 @@ namespace Box.V2.Managers
             id.ThrowIfNullOrWhiteSpace("id");
             sharedLinkRequest.ThrowIfNull("sharedLinkRequest");
 
+            sharedLinkRequest.EnsureEditIsFalse();
+
             BoxRequest request = new BoxRequest(_config.WebLinksEndpointUri, id)
                 .Method(RequestMethod.Put)
                 .Param(ParamFields, fields)

--- a/Box.V2/Managers/BoxWebLinksManager.cs
+++ b/Box.V2/Managers/BoxWebLinksManager.cs
@@ -130,7 +130,8 @@ namespace Box.V2.Managers
             id.ThrowIfNullOrWhiteSpace("id");
             sharedLinkRequest.ThrowIfNull("sharedLinkRequest");
 
-            sharedLinkRequest.EnsureEditIsFalse();
+            if (sharedLinkRequest.Permissions != null)
+                sharedLinkRequest.Permissions.Edit.ThrowIfDifferent("sharedLinkRequest.permissions.can_edit", false);
 
             BoxRequest request = new BoxRequest(_config.WebLinksEndpointUri, id)
                 .Method(RequestMethod.Put)

--- a/Box.V2/Models/BoxPermission.cs
+++ b/Box.V2/Models/BoxPermission.cs
@@ -18,5 +18,11 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty("can_preview")]
         public virtual bool CanPreview { get; set; }
+
+        /// <summary>
+        /// Whether the item can be edited or not
+        /// </summary>
+        [JsonProperty("can_edit")]
+        public virtual bool? CanEdit { get; set; }
     }
 }

--- a/Box.V2/Models/Request/BoxPermissionsRequest.cs
+++ b/Box.V2/Models/Request/BoxPermissionsRequest.cs
@@ -22,6 +22,13 @@ namespace Box.V2.Models
         [JsonProperty(PropertyName = "can_preview")]
         [JsonConverter(typeof(StringEnumConverter))]
         public BoxPermissionType? Preview { get; set; }
+
+        /// <summary>
+        /// Defines if the shared link allows for the item to be edited.
+        /// This value can only be true if can_download is also true and if the item has a type of file
+        /// </summary>
+        [JsonProperty(PropertyName = "can_edit")]
+        public bool? Edit { get; set; }
     }
 
     /// <summary>

--- a/Box.V2/Models/Request/BoxSharedLinkRequest.cs
+++ b/Box.V2/Models/Request/BoxSharedLinkRequest.cs
@@ -61,14 +61,6 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = "vanity_name")]
         public string VanityName { get; set; }
-
-        internal void EnsureEditIsFalse()
-        {
-            if (Permissions != null && Permissions.Edit == true)
-            {
-                Permissions.Edit = false;
-            }
-        }
     }
 }
 

--- a/Box.V2/Models/Request/BoxSharedLinkRequest.cs
+++ b/Box.V2/Models/Request/BoxSharedLinkRequest.cs
@@ -61,6 +61,14 @@ namespace Box.V2.Models
         /// </summary>
         [JsonProperty(PropertyName = "vanity_name")]
         public string VanityName { get; set; }
+
+        internal void EnsureEditIsFalse()
+        {
+            if (Permissions != null && Permissions.Edit == true)
+            {
+                Permissions.Edit = false;
+            }
+        }
     }
 }
 


### PR DESCRIPTION
I decided to model the SDK like open-api (can-edit for File, Folder and WebLink). An exception is thrown when you try to set `can_edit` `true` for Folder or WebLink. The API throws an exception when you do this, so we can throw it earlier.

Another possible solution would be to either separate SharedLink for File, Folder, and WebLink (a breaking change), or deprecate the existing methods in favor of new ones with new DTOs.