### PR TITLE
fix: replace infinite retries with exponential backoff strategy in file representations

### DIFF
--- a/Box.V2.Test/Box.V2.Test.csproj
+++ b/Box.V2.Test/Box.V2.Test.csproj
@@ -47,6 +47,12 @@
     <None Update="Fixtures\BoxFileRequest\GetFileRequest200.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="Fixtures\BoxFiles\PollRepresentationPending200.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Fixtures\BoxFiles\GetRepresentationContentPending200.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Fixtures\BoxFiles\CreateFileSharedLink200.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Box.V2.Test/BoxFilesManagerTest.cs
+++ b/Box.V2.Test/BoxFilesManagerTest.cs
@@ -4,7 +4,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Text;
 using System.Threading.Tasks;
 using Box.V2.Exceptions;
@@ -1200,6 +1199,111 @@ namespace Box.V2.Test
                 Assert.AreEqual(status.NameConflicts[1].items[1].OriginalName, "employees");
                 Assert.AreNotEqual(fs.Length, 0);
             }
+        }
+
+
+        [TestMethod]
+        [ExpectedException(typeof(BoxCodingException))]
+        public async Task GetRepresentationContentAsync_ShouldThrowException_IfTooManyRetriesAndHandleRetryTrue()
+        {
+            Handler.SetupSequence(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
+                 .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                 {
+                     Status = ResponseStatus.Success,
+                     StatusCode = System.Net.HttpStatusCode.Accepted,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/GetRepresentationContentPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                 {
+                     Status = ResponseStatus.Success,
+                     StatusCode = System.Net.HttpStatusCode.Accepted,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/GetRepresentationContentPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                 {
+                     Status = ResponseStatus.Success,
+                     StatusCode = System.Net.HttpStatusCode.Accepted,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/GetRepresentationContentPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                 {
+                     Status = ResponseStatus.Success,
+                     StatusCode = System.Net.HttpStatusCode.Accepted,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/GetRepresentationContentPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                 {
+                     Status = ResponseStatus.Success,
+                     StatusCode = System.Net.HttpStatusCode.Accepted,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/GetRepresentationContentPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                 {
+                     Status = ResponseStatus.Success,
+                     StatusCode = System.Net.HttpStatusCode.Accepted,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/GetRepresentationContentPending200.json")
+                 }));
+
+            var repRequest = new BoxRepresentationRequest
+            {
+                FileId = "11111",
+                XRepHints = $"[jpg?dimensions=320x320]",
+                HandleRetry = true
+            };
+
+            var result = await _filesManager.GetRepresentationContentAsync(repRequest);
+        }
+
+        [TestMethod]
+        [ExpectedException(typeof(BoxCodingException))]
+        public async Task GetRepresentationContentAsync_ShouldThrowException_IfTooManyRetries()
+        {
+            Handler.Setup(h => h.ExecuteAsync<BoxFile>(It.IsAny<IBoxRequest>()))
+                 .Returns(Task.FromResult<IBoxResponse<BoxFile>>(new BoxResponse<BoxFile>()
+                 {
+                     Status = ResponseStatus.Success,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/GetRepresentationContentPending200.json")
+                 }));
+
+            Handler.SetupSequence(h => h.ExecuteAsync<BoxRepresentation>(It.IsAny<IBoxRequest>()))
+                 .Returns(Task.FromResult<IBoxResponse<BoxRepresentation>>(new BoxResponse<BoxRepresentation>()
+                 {
+                     Status = ResponseStatus.Success,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/PollRepresentationPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxRepresentation>>(new BoxResponse<BoxRepresentation>()
+                 {
+                     Status = ResponseStatus.Success,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/PollRepresentationPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxRepresentation>>(new BoxResponse<BoxRepresentation>()
+                 {
+                     Status = ResponseStatus.Success,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/PollRepresentationPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxRepresentation>>(new BoxResponse<BoxRepresentation>()
+                 {
+                     Status = ResponseStatus.Success,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/PollRepresentationPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxRepresentation>>(new BoxResponse<BoxRepresentation>()
+                 {
+                     Status = ResponseStatus.Success,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/PollRepresentationPending200.json")
+                 }))
+                 .Returns(Task.FromResult<IBoxResponse<BoxRepresentation>>(new BoxResponse<BoxRepresentation>()
+                 {
+                     Status = ResponseStatus.Success,
+                     ContentString = LoadFixtureFromJson("Fixtures/BoxFiles/PollRepresentationPending200.json")
+                 }));
+
+            var repRequest = new BoxRepresentationRequest
+            {
+                FileId = "11111",
+                XRepHints = $"[jpg?dimensions=320x320]",
+            };
+
+            var result = await _filesManager.GetRepresentationContentAsync(repRequest);
         }
     }
 }

--- a/Box.V2.Test/BoxResourceManagerTest.cs
+++ b/Box.V2.Test/BoxResourceManagerTest.cs
@@ -6,6 +6,7 @@ using Box.V2.Config;
 using Box.V2.Converter;
 using Box.V2.Request;
 using Box.V2.Services;
+using Box.V2.Test.Helpers;
 using Moq;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -49,6 +50,7 @@ namespace Box.V2.Test
             Config.SetupGet(x => x.SignRequestsEndpointUri).Returns(SignRequestUri);
             Config.SetupGet(x => x.SignRequestsEndpointWithPathUri).Returns(SignRequestWithPathUri);
             Config.SetupGet(x => x.FileRequestsEndpointWithPathUri).Returns(FileRequestsWithPathUri);
+            Config.SetupGet(x => x.RetryStrategy).Returns(new InstantRetryStrategy());
 
             AuthRepository = new AuthRepository(Config.Object, Service, Converter, new OAuthSession("fakeAccessToken", "fakeRefreshToken", 3600, "bearer"));
         }

--- a/Box.V2.Test/Fixtures/BoxFiles/GetRepresentationContentPending200.json
+++ b/Box.V2.Test/Fixtures/BoxFiles/GetRepresentationContentPending200.json
@@ -12,13 +12,13 @@
           "thumb": "false"
         },
         "info": {
-          "url": "https:\/\/api.box.com\/2.0\/internal_files\/11111\/versions\/22222\/representations\/jpg_320x320"
+          "url": "https://api.box.com/2.0/internal_files/11111/versions/22222/representations/jpg_320x320"
         },
         "status": {
           "state": "pending"
         },
         "content": {
-          "url_template": "https:\/\/dl.boxcloud.com\/api\/2.0\/internal_files\/11111\/versions\/22222\/representations\/jpg_320x320\/content\/{+asset_path}"
+          "url_template": "https://dl.boxcloud.com/api/2.0/internal_files/11111/versions/22222/representations/jpg_320x320/content/{+asset_path}"
         }
       }
     ]

--- a/Box.V2.Test/Fixtures/BoxFiles/GetRepresentationContentPending200.json
+++ b/Box.V2.Test/Fixtures/BoxFiles/GetRepresentationContentPending200.json
@@ -1,0 +1,27 @@
+{
+  "type": "file",
+  "id": "11111",
+  "etag": "0",
+  "representations": {
+    "entries": [
+      {
+        "representation": "jpg",
+        "properties": {
+          "dimensions": "320x320",
+          "paged": "false",
+          "thumb": "false"
+        },
+        "info": {
+          "url": "https:\/\/api.box.com\/2.0\/internal_files\/11111\/versions\/22222\/representations\/jpg_320x320"
+        },
+        "status": {
+          "state": "pending"
+        },
+        "content": {
+          "url_template": "https:\/\/dl.boxcloud.com\/api\/2.0\/internal_files\/11111\/versions\/22222\/representations\/jpg_320x320\/content\/{+asset_path}"
+        }
+      }
+    ]
+  }
+}
+

--- a/Box.V2.Test/Fixtures/BoxFiles/PollRepresentationPending200.json
+++ b/Box.V2.Test/Fixtures/BoxFiles/PollRepresentationPending200.json
@@ -1,0 +1,17 @@
+{
+  "representation": "jpg",
+  "properties": {
+    "dimensions": "320x320",
+    "paged": "false",
+    "thumb": "false"
+  },
+  "info": {
+    "url": "https:\/\/api.box.com\/2.0\/internal_files\/11111\/versions\/22222\/representations\/jpg_320x320"
+  },
+  "status": {
+    "state": "pending"
+  },
+  "content": {
+    "url_template": "https:\/\/dl.boxcloud.com\/api\/2.0\/internal_files\/11111\/versions\/22222\/representations\/jpg_320x320\/content\/{+asset_path}"
+  }
+}

--- a/Box.V2.Test/Fixtures/BoxFiles/PollRepresentationPending200.json
+++ b/Box.V2.Test/Fixtures/BoxFiles/PollRepresentationPending200.json
@@ -6,12 +6,12 @@
     "thumb": "false"
   },
   "info": {
-    "url": "https:\/\/api.box.com\/2.0\/internal_files\/11111\/versions\/22222\/representations\/jpg_320x320"
+    "url": "https://api.box.com/2.0/internal_files/11111/versions/22222/representations/jpg_320x320"
   },
   "status": {
     "state": "pending"
   },
   "content": {
-    "url_template": "https:\/\/dl.boxcloud.com\/api\/2.0\/internal_files\/11111\/versions\/22222\/representations\/jpg_320x320\/content\/{+asset_path}"
+    "url_template": "https://dl.boxcloud.com/api/2.0/internal_files/11111/versions/22222/representations/jpg_320x320/content/{+asset_path}"
   }
 }

--- a/Box.V2/Config/BoxConfig.cs
+++ b/Box.V2/Config/BoxConfig.cs
@@ -66,6 +66,7 @@ namespace Box.V2.Config
             AcceptEncoding = builder.AcceptEncoding;
             WebProxy = builder.WebProxy;
             Timeout = builder.Timeout;
+            RetryStrategy = builder.RetryStrategy;
         }
 
         /// <summary>
@@ -292,6 +293,11 @@ namespace Box.V2.Config
         /// Timeout for the connection
         /// </summary>
         public TimeSpan? Timeout { get; private set; }
+
+        /// <summary>
+        /// Retry strategy for failed requests
+        /// </summary>
+        public IRetryStrategy RetryStrategy { get; private set; } = new ExponentialBackoff();
     }
 
     public enum CompressionType

--- a/Box.V2/Config/BoxConfigBuilder.cs
+++ b/Box.V2/Config/BoxConfigBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Net;
+using Box.V2.Utility;
 
 namespace Box.V2.Config
 {
@@ -251,6 +252,17 @@ namespace Box.V2.Config
             return this;
         }
 
+        /// <summary>
+        /// Sets retry strategy.
+        /// </summary>
+        /// <param name="enterpriseId">Retry strategy.</param>
+        /// <returns>this BoxConfigBuilder object for chaining</returns>
+        public BoxConfigBuilder SetRetryStrategy(IRetryStrategy retryStrategy)
+        {
+            RetryStrategy = retryStrategy;
+            return this;
+        }
+
         public string ClientId { get; private set; }
         public string ClientSecret { get; private set; }
         public string EnterpriseId { get; private set; }
@@ -297,6 +309,11 @@ namespace Box.V2.Config
         /// Timeout for the connection
         /// </summary>
         public TimeSpan? Timeout { get; private set; }
+
+        /// <summary>
+        /// Retry strategy for failed requests
+        /// </summary>
+        public IRetryStrategy RetryStrategy { get; private set; } = new ExponentialBackoff();
 
         private Uri EnsureEndsWithSlash(Uri uri)
         {

--- a/Box.V2/Config/IBoxConfig.cs
+++ b/Box.V2/Config/IBoxConfig.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Net;
+using Box.V2.Utility;
 
 namespace Box.V2.Config
 {
@@ -143,5 +144,9 @@ namespace Box.V2.Config
         /// Timeout for the connection
         /// </summary>
         TimeSpan? Timeout { get; }
+        /// <summary>
+        /// Retry strategy for failed requests
+        /// </summary>
+        IRetryStrategy RetryStrategy { get; }
     }
 }


### PR DESCRIPTION
Fixed infinite loop retries. We now use exponential backoff strategy like in the rest of the SDK. I also exposed `IRetryStrategy` that is used in tests for now.