### PR TITLE
fix: fix null reference exception when it's not possible to get `runtime` version from the assembly

### DIFF
--- a/Box.V2/Managers/BoxResourceManager.cs
+++ b/Box.V2/Managers/BoxResourceManager.cs
@@ -389,8 +389,12 @@ namespace Box.V2.Managers
                     null;
             }
 
+#if NETSTANDARD2_0
             var frameworkVersion = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
             return Regex.Match(frameworkVersion, @"\d+(\.\d+)+").Value;
+#else
+            return ""; 
+#endif
         }
 
     }

--- a/Box.V2/Managers/BoxResourceManager.cs
+++ b/Box.V2/Managers/BoxResourceManager.cs
@@ -390,10 +390,7 @@ namespace Box.V2.Managers
             }
 
             var frameworkVersion = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
-
-            var match = Regex.Match(frameworkVersion, @"\d+(\.\d+)+").Value;
-
-            return match;
+            return Regex.Match(frameworkVersion, @"\d+(\.\d+)+").Value;
         }
 
     }

--- a/Box.V2/Managers/BoxResourceManager.cs
+++ b/Box.V2/Managers/BoxResourceManager.cs
@@ -393,9 +393,8 @@ namespace Box.V2.Managers
             var frameworkVersion = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
             return Regex.Match(frameworkVersion, @"\d+(\.\d+)+").Value;
 #else
-            return null; 
+            return null;
 #endif
         }
-
     }
 }

--- a/Box.V2/Managers/BoxResourceManager.cs
+++ b/Box.V2/Managers/BoxResourceManager.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Reflection;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace Box.V2.Managers
@@ -379,11 +380,20 @@ namespace Box.V2.Managers
         private string GetNetCoreVersion()
         {
             var assembly = typeof(System.Runtime.GCSettings).GetTypeInfo().Assembly;
-            var assemblyPath = assembly.CodeBase.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
-            var netCoreAppIndex = Array.IndexOf(assemblyPath, "Microsoft.NETCore.App");
-            return netCoreAppIndex > 0 && netCoreAppIndex < assemblyPath.Length - 2 ?
-                assemblyPath[netCoreAppIndex + 1] :
-                null;
+            if (assembly?.CodeBase != null)
+            {
+                var assemblyPath = assembly.CodeBase.Split(new[] { '/', '\\' }, StringSplitOptions.RemoveEmptyEntries);
+                var netCoreAppIndex = Array.IndexOf(assemblyPath, "Microsoft.NETCore.App");
+                return netCoreAppIndex > 0 && netCoreAppIndex < assemblyPath.Length - 2 ?
+                    assemblyPath[netCoreAppIndex + 1] :
+                    null;
+            }
+
+            var frameworkVersion = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
+
+            var match = Regex.Match(frameworkVersion, @"\d+(\.\d+)+").Value;
+
+            return match;
         }
 
     }

--- a/Box.V2/Managers/BoxResourceManager.cs
+++ b/Box.V2/Managers/BoxResourceManager.cs
@@ -393,7 +393,7 @@ namespace Box.V2.Managers
             var frameworkVersion = System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
             return Regex.Match(frameworkVersion, @"\d+(\.\d+)+").Value;
 #else
-            return ""; 
+            return null; 
 #endif
         }
 

--- a/Box.V2/Request/HttpRequestHandler.cs
+++ b/Box.V2/Request/HttpRequestHandler.cs
@@ -269,7 +269,11 @@ namespace Box.V2.Request
 
             private static HttpClient CreateClient(bool followRedirect, IWebProxy webProxy)
             {
-                var handler = new HttpClientHandler() { AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip };
+                var handler = new HttpClientHandler();
+                if (handler.SupportsAutomaticDecompression)
+                {
+                    handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
+                }
                 handler.AllowAutoRedirect = followRedirect;
 
                 if (webProxy != null)


### PR DESCRIPTION
If runtime version cannot be determined from assembly or in case of Blazor use the preferred way to get runtime version introduced in .net core 3.0

Also added check for AutomaticDecompression settings for HttpHandler, because it's not supported in Blazor at the moment.