### PR TITLE
fix: Catch all exceptions when getting `User Agent` header

### DIFF
--- a/Box.V2/Managers/BoxResourceManager.cs
+++ b/Box.V2/Managers/BoxResourceManager.cs
@@ -302,11 +302,7 @@ namespace Box.V2.Managers
             {
                 ndpKey = RegistryKey.OpenBaseKey(RegistryHive.LocalMachine, RegistryView.Registry32).OpenSubKey(Subkey);
             }
-            catch (UnauthorizedAccessException)
-            {
-                return "";
-            }
-            catch (SecurityException)
+            catch (Exception)
             {
                 return "";
             }


### PR DESCRIPTION
Closes: SDK-3096