### PR TITLE
fix: replace deprecated `BouncyCastle`

### DIFF
--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -44,8 +44,8 @@
     <AssemblyOriginatorKeyFile>BoxSDKKey.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="BouncyCastle.Crypto, Version=1.8.9.0, Culture=neutral, PublicKeyToken=0e99375e54769942">
-      <HintPath>..\packages\BouncyCastle.1.8.9\lib\BouncyCastle.Crypto.dll</HintPath>
+    <Reference Include="BouncyCastle.Cryptography, Version=2.0.0.0, Culture=neutral, PublicKeyToken=072edcf4a5328938, processorArchitecture=MSIL">
+      <HintPath>..\packages\BouncyCastle.Cryptography.2.2.1\lib\net461\BouncyCastle.Cryptography.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel.JsonWebTokens, Version=6.12.2.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.JsonWebTokens.6.12.2\lib\net45\Microsoft.IdentityModel.JsonWebTokens.dll</HintPath>

--- a/Box.V2/packages.config
+++ b/Box.V2/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle" version="1.8.9" targetFramework="net462" />
+  <package id="BouncyCastle.Cryptography" version="2.2.1" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.JsonWebTokens" version="6.12.2" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Logging" version="6.12.2" targetFramework="net462" />
   <package id="Microsoft.IdentityModel.Tokens" version="6.12.2" targetFramework="net462" />


### PR DESCRIPTION
Replace deprecated BouncyCastle.Crypto with BouncyCastle.Cryptography