### PR TITLE
feat: add `attachment` content type to `SignRequestSigner`

### DIFF
--- a/Box.V2/Models/BoxSignRequestSigner.cs
+++ b/Box.V2/Models/BoxSignRequestSigner.cs
@@ -188,7 +188,8 @@ namespace Box.V2.Models
         last_name,
         text,
         date,
-        checkbox
+        checkbox,
+        attachment
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes #912 

Same as in the spec: https://developer.box.com/reference/resources/sign-request/#param-signers-inputs-content_type