### PR TITLE
fix: do not recreate Random each time

### DIFF
--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -276,6 +276,7 @@
     <Compile Include="Utility\ContentTypeMapper.cs" />
     <Compile Include="Utility\Retry.cs" />
     <Compile Include="Utility\SharedLinkUtils.cs" />
+    <Compile Include="Utility\ThreadSafeRandom.cs" />
     <Compile Include="Wrappers\BoxError.cs" />
     <Compile Include="Wrappers\BoxErrorContextInfo.cs" />
     <Compile Include="Wrappers\BoxBinaryRequest.cs" />

--- a/Box.V2/Utility/ExponentialBackoff.cs
+++ b/Box.V2/Utility/ExponentialBackoff.cs
@@ -4,8 +4,6 @@ namespace Box.V2.Utility
 {
     public class ExponentialBackoff : IRetryStrategy
     {
-        private readonly Random _random = new Random();
-
         public TimeSpan GetRetryTimeout(int numRetries)
         {
             var baseInterval = TimeSpan.FromSeconds(2.0);
@@ -13,7 +11,9 @@ namespace Box.V2.Utility
             var minRandomization = 1 - RETRY_RANDOMIZATION_FACTOR;
             var maxRandomization = 1 + RETRY_RANDOMIZATION_FACTOR;
 
-            var randomization = _random.NextDouble() * (maxRandomization - minRandomization) + minRandomization;
+            var randomization = ThreadSafeRandom.Instance.NextDouble()
+                * (maxRandomization - minRandomization) + minRandomization;
+
             var exponential = Math.Pow(2, numRetries - 1);
             var result = Math.Ceiling(exponential * baseInterval.TotalSeconds * randomization);
             return TimeSpan.FromSeconds(result);

--- a/Box.V2/Utility/ExponentialBackoff.cs
+++ b/Box.V2/Utility/ExponentialBackoff.cs
@@ -4,15 +4,16 @@ namespace Box.V2.Utility
 {
     public class ExponentialBackoff : IRetryStrategy
     {
+        private readonly Random _random = new Random();
+
         public TimeSpan GetRetryTimeout(int numRetries)
         {
             var baseInterval = TimeSpan.FromSeconds(2.0);
             const double RETRY_RANDOMIZATION_FACTOR = 0.5;
             var minRandomization = 1 - RETRY_RANDOMIZATION_FACTOR;
             var maxRandomization = 1 + RETRY_RANDOMIZATION_FACTOR;
-            var random = new Random();
 
-            var randomization = random.NextDouble() * (maxRandomization - minRandomization) + minRandomization;
+            var randomization = _random.NextDouble() * (maxRandomization - minRandomization) + minRandomization;
             var exponential = Math.Pow(2, numRetries - 1);
             var result = Math.Ceiling(exponential * baseInterval.TotalSeconds * randomization);
             return TimeSpan.FromSeconds(result);

--- a/Box.V2/Utility/ThreadSafeRandom.cs
+++ b/Box.V2/Utility/ThreadSafeRandom.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Box.V2.Utility
+{
+    /// <summary>
+    /// A thread safe implementation of <see cref="Random"/>, following best practices
+    /// for .NET Framework, .NET Standard, and .NET 6+.
+    /// </summary>
+    /// <seealso href="https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-random"/>
+    internal static class ThreadSafeRandom
+    {
+#if NET6_0_OR_GREATER
+        /// <summary>
+        /// An instance of <see cref="Random"/> specific to the calling thread.
+        /// Do not pass this instance to other threads or contexts.
+        /// </summary>
+        public static Random Instance => Random.Shared;
+#else
+        //
+        // Adapted from https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Random.cs
+        //
+
+        [ThreadStatic]
+        private static Random _random;
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        private static Random CreateRandom() => _random = new Random();
+
+        /// <summary>
+        /// An instance of <see cref="Random"/> specific to the calling thread.
+        /// Do not pass this instance to other threads or contexts.
+        /// </summary>
+        public static Random Instance => _random ?? CreateRandom();
+#endif
+    }
+}

--- a/Box.V2/Utility/ThreadSafeRandom.cs
+++ b/Box.V2/Utility/ThreadSafeRandom.cs
@@ -5,20 +5,15 @@ namespace Box.V2.Utility
 {
     /// <summary>
     /// A thread safe implementation of <see cref="Random"/>, following best practices
-    /// for .NET Framework, .NET Standard, and .NET 6+.
+    /// for .NET Framework and .NET Standard.
     /// </summary>
     /// <seealso href="https://learn.microsoft.com/en-us/dotnet/fundamentals/runtime-libraries/system-random"/>
     internal static class ThreadSafeRandom
     {
-#if NET6_0_OR_GREATER
-        /// <summary>
-        /// An instance of <see cref="Random"/> specific to the calling thread.
-        /// Do not pass this instance to other threads or contexts.
-        /// </summary>
-        public static Random Instance => Random.Shared;
-#else
         //
         // Adapted from https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Random.cs
+        //
+        // NOTE: when/if this library updates to .NET 6+, this code can be replaced with `Random.Shared`
         //
 
         [ThreadStatic]
@@ -32,6 +27,5 @@ namespace Box.V2.Utility
         /// Do not pass this instance to other threads or contexts.
         /// </summary>
         public static Random Instance => _random ?? CreateRandom();
-#endif
     }
 }


### PR DESCRIPTION
On .NET Framework it is incorrect to recreate Random instances each time, these should instead be one per instance. On .NET Core and later this is not a limitation, but the libraries share a codebase.

Fixes #944