### PR TITLE
fix: Add missing enum values to `BoxSortBy`

### DIFF
--- a/Box.V2.Test.Integration/BoxFolderManagerIntegrationTest.cs
+++ b/Box.V2.Test.Integration/BoxFolderManagerIntegrationTest.cs
@@ -236,7 +236,7 @@ namespace Box.V2.Test.Integration
 
             var sharedItems = await UserClient.SharedItemsManager.SharedItemsAsync(sharedLink.SharedLink.Url, password);
             var items = await UserClient.FoldersManager.GetFolderItemsAsync(sharedItems.Id, 100, sharedLink: sharedLink.SharedLink.Url,
-                sharedLinkPassword: password);
+                sharedLinkPassword: password, sort: "date");
 
 
             Assert.AreEqual(items.TotalCount, 1);

--- a/Box.V2/Models/BoxEnums.cs
+++ b/Box.V2/Models/BoxEnums.cs
@@ -33,7 +33,9 @@ namespace Box.V2.Models
         retention_policy_id,
         retention_policy_object_id,
         retention_policy_set_id,
-        interacted_at
+        interacted_at,
+        date,
+        size
     }
 
     /// <summary>


### PR DESCRIPTION
Fixes: #952