### PR TITLE
fix: remove `Microsoft.AspNetCore.StaticFiles` and `System.Web` dependencies

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # Set default behaviour to automatically normalize line endings.
 * text=auto
+*.cs text eol=crlf

--- a/Box.V2.Core/Box.V2.Core.csproj
+++ b/Box.V2.Core/Box.V2.Core.csproj
@@ -37,7 +37,6 @@
   </ItemGroup>
 
     <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/Box.V2/Box.V2.csproj
+++ b/Box.V2/Box.V2.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -97,7 +97,6 @@
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/Box.V2/Utility/ContentTypeMapper.cs
+++ b/Box.V2/Utility/ContentTypeMapper.cs
@@ -1,24 +1,51 @@
+using System.Collections.Generic;
+using System.IO;
+
 namespace Box.V2.Utility
 {
+    /// <summary>
+    /// Utility class for determining Content-Type header. Should only be used internally by the SDK.
+    /// </summary>
     public static class ContentTypeMapper
     {
+        private static readonly Dictionary<string, string> _mimeMapping = new Dictionary<string, string>()
+        {
+            { ".jpe", "image/jpeg" },
+            { ".jpeg", "image/jpeg" },
+            { ".jpg", "image/jpeg" },
+            { ".bmp", "image/bmp" },
+            { ".png", "image/png" },
+            { ".gif", "image/gif" },
+            { ".webp", "image/webp" },
+        };
+
+        /// <summary>
+        /// Get Content-Type header from a filename. Supports most common image formats. Should only be used internally by the SDK.
+        /// </summary>
+        /// <param name="filename">full filename with extension</param>
+        /// <returns>Content-Type header as a string</returns>
         public static string GetContentTypeFromFilename(string filename)
         {
             const string DefaultContentType = "application/octet-stream";
             var contentType = DefaultContentType;
 
-#if NETSTANDARD2_0
-            var provider = new Microsoft.AspNetCore.StaticFiles.FileExtensionContentTypeProvider();
-
-            if (provider.TryGetContentType(filename, out var contentTypeFromFile))
+            if (TryGetContentType(filename, out var contentTypeFromFile))
             {
                 contentType = contentTypeFromFile;
             }
-#else
-            contentType = System.Web.MimeMapping.GetMimeMapping(filename);
-#endif
 
             return contentType;
+        }
+
+        private static bool TryGetContentType(string path, out string contentType)
+        {
+            var extension = Path.GetExtension(path);
+            if (extension == null)
+            {
+                contentType = null;
+                return false;
+            }
+            return _mimeMapping.TryGetValue(extension, out contentType);
         }
     }
 }


### PR DESCRIPTION
Fixes #959 and #903 

Modified `.gitattributes` file due to the rule in `.editorconfig` for line endings of .cs file